### PR TITLE
bzImage kernel format support

### DIFF
--- a/.buildkite/deps-pipeline.yml
+++ b/.buildkite/deps-pipeline.yml
@@ -1,10 +1,10 @@
 steps:
   - label: "build-deps-x86"
     commands:
-      - resources/kernel/make_simple_kernel.sh -f elf -k vmlinux-hello-busybox -w /tmp/vmlinux_busybox -j 2
-      - resources/kernel/make_simple_kernel.sh -f elf -k vmlinux-hello-busybox -w /tmp/vmlinux_busybox -j 2 -h
-      - resources/kernel/make_simple_kernel.sh -f bzimage -k bzimage-hello-busybox -w /tmp/bzimage_busybox -j 2
-      - resources/kernel/make_simple_kernel.sh -f bzimage -k bzimage-hello-busybox -w /tmp/bzimage_busybox -j 2 -h
+      - resources/kernel/make_kernel_image.sh -f elf -k vmlinux-hello-busybox -w /tmp/vmlinux_busybox -j 2
+      - resources/kernel/make_kernel_image.sh -f elf -k vmlinux-hello-busybox -w /tmp/vmlinux_busybox -j 2 -h
+      - resources/kernel/make_kernel_image.sh -f bzimage -k bzimage-hello-busybox -w /tmp/vmlinux_busybox -j 2
+      - resources/kernel/make_kernel_image.sh -f bzimage -k bzimage-hello-busybox -w /tmp/vmlinux_busybox -j 2 -h
     retry:
       automatic: false
     agents:

--- a/.buildkite/deps-pipeline.yml
+++ b/.buildkite/deps-pipeline.yml
@@ -1,8 +1,10 @@
 steps:
   - label: "build-deps-x86"
     commands:
-      - resources/kernel/make_busybox.sh -j 2
-      - resources/kernel/make_busybox.sh -h -j 2
+      - resources/kernel/make_simple_kernel.sh -f elf -k vmlinux-hello-busybox -w /tmp/vmlinux_busybox -j 2
+      - resources/kernel/make_simple_kernel.sh -f elf -k vmlinux-hello-busybox -w /tmp/vmlinux_busybox -j 2 -h
+      - resources/kernel/make_simple_kernel.sh -f bzimage -k bzimage-hello-busybox -w /tmp/bzimage_busybox -j 2
+      - resources/kernel/make_simple_kernel.sh -f bzimage -k bzimage-hello-busybox -w /tmp/bzimage_busybox -j 2 -h
     retry:
       automatic: false
     agents:

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -18,6 +18,7 @@ KERNEL_BINS=(
 arch=$(dpkg --print-architecture)
 if [ "$arch" == "amd64" ]; then
     for bin in "${KERNEL_BINS[@]}"; do
-        cp "$WORKDIR/$KERNEL/$bin" "$RESDIR"
+        path="$WORKDIR/$KERNEL/$bin"
+        ([ -f "$path" ] && cp "$path" "$RESDIR") || true
     done
 fi

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -8,7 +8,12 @@
 RESDIR="resources/kernel"
 WORKDIR="/tmp/vmlinux_busybox"
 KERNEL="linux-4.14.176"
-KERNEL_BINS=(vmlinux-hello-busybox vmlinux-hello-busybox-halt)
+KERNEL_BINS=(
+    "vmlinux-hello-busybox"
+    "vmlinux-hello-busybox-halt"
+    "bzimage-hello-busybox"
+    "bzimage-hello-busybox-halt"
+)
 
 arch=$(dpkg --print-architecture)
 if [ "$arch" == "amd64" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 vmlinux-hello-busybox*
+bzimage-hello-busybox*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vm-device"
 version = "0.1.0"
-source = "git+https://github.com/aghecenco/vm-device.git?branch=send#359ddf304baece61635a0538595e0a53fcc9e76b"
+source = "git+https://github.com/rust-vmm/vm-device.git#5847f1286492b7191f1400e6647fb220f8941f89"
 
 [[package]]
 name = "vm-memory"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {  
-  "coverage_score": 88.9,
+  "coverage_score": 89.0,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/",
   "crate_features": ""
 }

--- a/resources/kernel/make_kernel.sh
+++ b/resources/kernel/make_kernel.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+# This script contains functions for compiling a Linux kernel and initramfs.
+
+KERNEL_URL_BASE="https://cdn.kernel.org/pub/linux/kernel"
+
+die() {
+    echo "[ERROR] $1" >&2
+    echo "$USAGE" >&2 # To be filled by the caller.
+    # Kill the caller.
+    if [ -n "$TOP_PID" ]; then kill -s TERM "$TOP_PID"; else exit 1; fi
+}
+
+pushd_quiet() {
+    pushd "$1" &>/dev/null || die "Failed to enter $1."
+}
+
+popd_quiet() {
+    popd &>/dev/null || die "Failed to return to previous directory."
+}
+
+# Usage:
+#   extract_kernel_srcs kernel_version
+extract_kernel_srcs() {
+    kernel_version="$1"
+
+    [ -z "$kernel_version" ] && die "Kernel version not specified."
+    
+    # This magic trick gets the major component of the version number.
+    kernel_major="${kernel_version%%.*}"
+    kernel_archive="linux-$kernel_version.tar.xz"
+    kernel_url="$KERNEL_URL_BASE/v$kernel_major.x/$kernel_archive"
+
+    echo "Starting kernel build."
+    # Download kernel sources.
+    echo "Downloading kernel..."
+    [ -f "$kernel_archive" ] || curl "$kernel_url" > "$kernel_archive"
+    echo "Extracting kernel sources..."
+    tar --skip-old-files -xf "$kernel_archive"
+}
+
+# Usage:
+#   make_kernel_config /path/to/source/config /path/to/kernel
+make_kernel_config() {
+    # Copy base kernel config.
+    # Add any custom config options, if necessary (currently N/A).
+    kernel_config="$1"
+    kernel_dir="$2"
+
+    [ -z "$kernel_config" ] && die "Kernel config file not specified."
+    [ ! -f "$kernel_config" ] && die "Kernel config file not found."
+    [ -z "$kernel_dir" ] && die "Kernel directory not specified."
+    [ ! -d "$kernel_dir" ] && die "Kernel directory not found."
+
+    echo "Copying kernel config..."
+    cp "$kernel_config" "$kernel_dir/.config"
+}
+
+# Usage:
+#   make_initramfs              \
+#       /path/to/kernel/dir     \
+#       /path/to/busybox/rootfs \
+#       [halt_value]
+make_initramfs() {
+    kernel_dir="$1"
+    busybox_rootfs="$2"
+    halt="$3"
+
+    [ -z "$kernel_dir" ] && die "Kernel directory not specified."
+    [ ! -d "$kernel_dir" ] && die "Kernel directory not found."
+    [ -z "$busybox_rootfs" ] && die "Busybox rootfs not specified."
+    [ ! -d "$busybox_rootfs" ] && die "Busybox rootfs directory not found."
+
+    # Move to the directory with the kernel sources.
+    pushd_quiet "$kernel_dir"
+
+    # Prepare initramfs directory.
+    mkdir -p initramfs/{bin,dev,etc,home,mnt,proc,sys,usr}
+    # Copy busybox.
+    echo "Copying busybox to the initramfs directory..."
+    cp -r "$busybox_rootfs"/* initramfs/
+
+    # Make a block device and a console.
+    pushd_quiet initramfs/dev
+    echo "Creating device nodes..."
+    rm -f sda && mknod sda b 8 0
+    rm -f console && mknod console c 5 1
+    rm -f ttyS0 && mknod ttyS0 c 4 64
+
+    make_init "$halt"
+
+    chmod +x init
+    fakeroot chown root init
+
+    # Pack it up...
+    echo "Packing initramfs.cpio..."
+    find . | cpio -H newc -o > ../initramfs.cpio
+    fakeroot chown root ../initramfs.cpio
+
+    # Return to kernel srcdir.
+    popd_quiet
+    # Return to previous directory.
+    popd_quiet
+}
+
+# Usage: validate_kernel_format format
+# Prints the lowercase format name, if one of "elf" or "bzimage".
+# Exits with error if any other format is specified.
+validate_kernel_format() {
+    format="$1"
+
+    kernel_fmt=$(echo "$format" | tr '[:upper:]' '[:lower:]')
+    if [ "$kernel_fmt" != "elf" ] && [ "$kernel_fmt" != "bzimage" ]; then
+        die "Invalid kernel binary format: $kernel_fmt."
+    fi
+    echo "$kernel_fmt"
+}
+
+# Usage: kernel_target format
+# Prints the `make` target that builds a kernel of the specified format.
+kernel_target() {
+    format=$(validate_kernel_format "$1")
+
+    case "$format" in
+    elf)        echo "vmlinux"
+                ;;
+    bzimage)    # This is the default target.
+                ;;
+    esac
+}
+
+# Usage: kernel_binary format
+# Prints the name of the generated kernel binary.
+kernel_binary() {
+    format=$(validate_kernel_format "$1")
+    
+    case "$format" in
+    elf)        echo "vmlinux"
+                ;;
+    bzimage)    echo "arch/x86/boot/bzImage"
+                ;;
+    esac
+}
+
+# Usage:
+#   make_kernel
+#       /path/to/kernel/dir \
+#       format              \
+#       [num_cpus_build]    \
+#       [/path/to/kernel/destination]
+make_kernel() {
+    kernel_dir="$1"
+    format="$2"
+    nprocs="$3"
+    dst="$4"
+
+    [ -z "$kernel_dir" ] && die "Kernel directory not specified."
+    [ ! -d "$kernel_dir" ] && die "Kernel directory not found."
+    [ -z "$format" ] && die "Kernel format not specified."
+    [ -z "$nprocs" ] && nprocs=1
+   
+    target=$(kernel_target "$format")
+    kernel_binary=$(kernel_binary "$format")
+
+    # Move to the directory with the kernel sources.
+    pushd_quiet "$kernel_dir"
+
+    # Build kernel.
+    echo "Building kernel..."
+    # Missing the quotes for $target is intentional: if the target is empty,
+    # quotes will cause it to be passed as an empty string, which `make`
+    # doesn't understand. No quotes => no empty string.
+    make -j "$nprocs" $target
+
+    if [ -n "$dst" ] && [ "$kernel_binary" != "$dst" ]; then
+        # Copy to destination.
+        cp "$kernel_binary" "$dst"
+    fi
+
+    # Return to previous directory.
+    popd_quiet
+}

--- a/resources/kernel/make_kernel_image.sh
+++ b/resources/kernel/make_kernel_image.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+# This script illustrates the build steps for kernel images used with the
+# reference VMM.
+
+set -e
+
+SOURCE=$(readlink -f "$0")
+TEST_RESOURCE_DIR="$(dirname "$SOURCE")"
+
+trap "exit 1" TERM
+export TOP_PID=$$
+
+source "$TEST_RESOURCE_DIR/make_busybox.sh"
+source "$TEST_RESOURCE_DIR/make_kernel.sh"
+
+KERNEL_VERSION="4.14.176"
+BUSYBOX_VERSION="1.26.0"
+
+KERNEL_CFG="microvm-kernel-initramfs-hello-x86_64.config"
+BUSYBOX_CFG="busybox_static_config"
+
+# Reset index for cmdline arguments for the following `getopts`.
+OPTIND=1
+# Flag for optionally building a guest that halts.
+HALT=
+# Number of CPUs to use during the kernel build process.
+MAKEPROCS=1
+# Flag for optionally cleaning the workdir and recompiling the kernel.
+CLEAN=
+# Working directory. Defaults to a unique tmpdir.
+WORKDIR=$(mktemp -d)
+# Kernel binary format.
+KERNEL_FMT=
+# Destination kernel binary name.
+KERNEL_BINARY=
+
+USAGE="
+Usage: $(basename $SOURCE) -f (elf|bzimage) [-j nprocs] [-k kernel] [-w workdir] [-c] [-h]
+
+Options:
+  -f elf|bzimage    Kernel image format (either elf or bzimage).
+  -j nprocs         Number of CPUs to use for the kernel build.
+  -k kernel         Name of the resulting kernel image. Has the '-halt' suffix if '-h' is passed.
+  -w workdir        Working directory for the kernel build.
+  -c                Clean up the working directory after the build.
+  -h                Create a kernel image that halts immediately after boot.
+"
+export USAGE
+
+while getopts ":chf:j:k:w:" opt; do
+    case "$opt" in
+    c)  CLEAN=1
+        ;;
+    h)  HALT=1
+        ;;
+    f)  KERNEL_FMT=$(validate_kernel_format "$OPTARG")
+        ;;
+    j)  MAKEPROCS=$OPTARG
+        ;;
+    k)  KERNEL_BINARY=$OPTARG
+        ;;
+    w)  rm -rf "$WORKDIR"
+        WORKDIR=$OPTARG
+        ;;
+    *)  echo "$USAGE"
+        exit 1
+    esac
+done
+shift $((OPTIND-1))
+
+cleanup() {
+    if [ -n "$CLEAN" ]; then
+        echo "Cleaning $WORKDIR..."
+        rm -rf "$WORKDIR"
+    fi
+}
+
+# Step 0: clean up the workdir, if the user wants to.
+cleanup
+
+# Step 1: what are we building?
+[ -z "$KERNEL_BINARY" ] && KERNEL_BINARY=$(kernel_binary "$KERNEL_FMT")
+[ -n "$HALT" ] && KERNEL_BINARY="$KERNEL_BINARY-halt"
+
+# Step 2: start from scratch.
+mkdir -p "$WORKDIR" && cd "$WORKDIR"
+
+# Step 3: acquire kernel sources & config.
+extract_kernel_srcs "$KERNEL_VERSION"
+kernel_dir="$WORKDIR/linux-$KERNEL_VERSION"
+make_kernel_config "$TEST_RESOURCE_DIR/$KERNEL_CFG" "$kernel_dir"
+
+# Step 4: make the initramfs.
+make_busybox "$WORKDIR" "$TEST_RESOURCE_DIR/$BUSYBOX_CFG"   \
+    "$BUSYBOX_VERSION" "$MAKEPROCS"
+make_initramfs "$kernel_dir" "$WORKDIR/busybox_rootfs" "$HALT"
+
+# Step 5: put them together.
+make_kernel "$kernel_dir" "$KERNEL_FMT" "$MAKEPROCS" "$KERNEL_BINARY"
+
+# Final step: profit!
+echo "Done!"
+echo "Kernel binary placed in: $kernel_dir/$KERNEL_BINARY"
+cleanup
+exit 0

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 event-manager = "0.2.0"
 kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.5.0"
-linux-loader = "0.2.0"
+linux-loader = { version = "0.2.0", features = ["bzimage", "elf"] }
 vm-device = { git = "https://github.com/aghecenco/vm-device.git", branch = "send" }
 vm-memory = { version = "0.3.0", features = ["backend-mmap"] }
 vm-superio = "0.1.1"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -9,7 +9,7 @@ event-manager = "0.2.0"
 kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.5.0"
 linux-loader = { version = "0.2.0", features = ["bzimage", "elf"] }
-vm-device = { git = "https://github.com/aghecenco/vm-device.git", branch = "send" }
+vm-device = { git = "https://github.com/rust-vmm/vm-device.git" }
 vm-memory = { version = "0.3.0", features = ["backend-mmap"] }
 vm-superio = "0.1.1"
 vmm-sys-util = "0.6.1"

--- a/src/vmm/src/config.rs
+++ b/src/vmm/src/config.rs
@@ -28,7 +28,7 @@ impl fmt::Display for ConversionError {
 }
 
 /// Guest memory configurations.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct MemoryConfig {
     /// Guest memory size in MiB.
     pub mem_size_mib: u32,
@@ -58,7 +58,7 @@ impl TryFrom<String> for MemoryConfig {
 }
 
 /// vCPU configurations.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct VcpuConfig {
     /// Number of vCPUs.
     pub num_vcpus: u8,
@@ -88,7 +88,7 @@ impl TryFrom<String> for VcpuConfig {
 }
 
 /// Guest kernel configurations.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct KernelConfig {
     /// Kernel command line.
     pub cmdline: String,
@@ -149,7 +149,7 @@ impl TryFrom<String> for KernelConfig {
 }
 
 /// VMM configuration.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct VMMConfig {
     /// Guest memory configuration.
     pub memory_config: MemoryConfig,

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -3,33 +3,25 @@
 
 #![cfg(target_arch = "x86_64")]
 
-extern crate libc;
-extern crate vmm;
-
-use std::convert::TryFrom;
 use std::path::PathBuf;
-use std::thread::sleep;
-use std::time::Duration;
 
-use libc::{_exit, fork, waitpid, WEXITSTATUS, WIFEXITED};
+use libc::fork;
 
-use vmm::{KernelConfig, MemoryConfig, VMMConfig, VcpuConfig, VMM};
+use vmm::{KernelConfig, MemoryConfig, VMMConfig, VcpuConfig};
 
 mod test_utils;
 use test_utils::*;
+
+const DEFAULT_BZIMAGE: &str = "../../resources/kernel/bzimage-hello-busybox-halt";
+const DEFAULT_ELF: &str = "../../resources/kernel/vmlinux-hello-busybox-halt";
 
 fn default_memory_config() -> MemoryConfig {
     MemoryConfig { mem_size_mib: 1024 }
 }
 
-fn default_kernel_config() -> KernelConfig {
-    let kernel_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../../resources/kernel/vmlinux-hello-busybox-halt");
-    // Sanity check. Because the VMM runs in a separate process, if the file doesn't exist,
-    // all we see is a different exit code than 0.
-    assert!(kernel_path.as_path().exists());
+fn default_kernel_config(path: PathBuf) -> KernelConfig {
     KernelConfig {
-        path: kernel_path,
+        path,
         himem_start: 0x0010_0000, // 1 MB
         cmdline: "console=ttyS0 i8042.nokbd reboot=k panic=1 pci=off".to_string(),
     }
@@ -39,41 +31,32 @@ fn default_vcpu_config() -> VcpuConfig {
     VcpuConfig { num_vcpus: 1 }
 }
 
-fn wait_vmm_child_process(vmm_pid: i32) {
-    // Parent process: wait for the vmm to exit.
-    let mut vmm_status: i32 = -1;
-    let pid_done = unsafe { waitpid(vmm_pid, &mut vmm_status, 0) };
-    assert_eq!(pid_done, vmm_pid);
-    restore_stdin();
-    assert!(WIFEXITED(vmm_status));
-    assert_eq!(WEXITSTATUS(vmm_status), 0);
-}
-
 #[test]
-fn test_dummy_vmm() {
+fn test_dummy_vmm_elf() {
     let pid = unsafe { fork() };
     let vmm_config = VMMConfig {
-        kernel_config: default_kernel_config(),
+        kernel_config: default_kernel_config(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_ELF),
+        ),
         memory_config: default_memory_config(),
         vcpu_config: default_vcpu_config(),
     };
-    match pid {
-        0 => {
-            set_panic_hook();
-            match VMM::try_from(vmm_config) {
-                Ok(mut vmm) => {
-                    vmm.run();
-                    // Shouldn't get here with this guest image. It will loop forever.
-                    unsafe { _exit(-1) };
-                }
-                _ => unsafe { _exit(1) },
-            }
-        }
-        vmm_pid => {
-            // Parent process: give the VMM some time, then check the exit code.
-            // It should terminate and return 0.
-            sleep(Duration::from_secs(5));
-            wait_vmm_child_process(vmm_pid);
-        }
-    }
+    // Sanity check. Because the VMM runs in a separate process, if the file doesn't exist,
+    // all we see is a different exit code than 0.
+    assert!(vmm_config.kernel_config.path.as_path().exists());
+    run_vmm(pid, vmm_config);
+}
+
+#[test]
+fn test_dummy_vmm_bzimage() {
+    let pid = unsafe { fork() };
+    let vmm_config = VMMConfig {
+        kernel_config: default_kernel_config(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(DEFAULT_BZIMAGE),
+        ),
+        memory_config: default_memory_config(),
+        vcpu_config: default_vcpu_config(),
+    };
+    assert!(vmm_config.kernel_config.path.as_path().exists());
+    run_vmm(pid, vmm_config);
 }

--- a/src/vmm/tests/test_utils/mod.rs
+++ b/src/vmm/tests/test_utils/mod.rs
@@ -1,9 +1,15 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::convert::TryFrom;
 use std::io;
 use std::panic;
+use std::thread::sleep;
+use std::time::Duration;
 
+use libc::{_exit, waitpid, WEXITSTATUS, WIFEXITED};
+
+use vmm::{VMMConfig, VMM};
 use vmm_sys_util::terminal::Terminal;
 
 const VMM_ERR_EXIT: i32 = -1;
@@ -20,4 +26,36 @@ pub fn set_panic_hook() {
             libc::exit(VMM_ERR_EXIT);
         }
     }));
+}
+
+fn wait_vmm_child_process(vmm_pid: i32) {
+    // Parent process: wait for the vmm to exit.
+    let mut vmm_status: i32 = -1;
+    let pid_done = unsafe { waitpid(vmm_pid, &mut vmm_status, 0) };
+    assert_eq!(pid_done, vmm_pid);
+    restore_stdin();
+    assert!(WIFEXITED(vmm_status));
+    assert_eq!(WEXITSTATUS(vmm_status), 0);
+}
+
+pub fn run_vmm(pid: i32, vmm_config: VMMConfig) {
+    match pid {
+        0 => {
+            set_panic_hook();
+            match VMM::try_from(vmm_config) {
+                Ok(mut vmm) => {
+                    vmm.run();
+                    // Shouldn't get here with this guest image.
+                    unsafe { _exit(-1) };
+                }
+                _ => unsafe { _exit(1) },
+            }
+        }
+        vmm_pid => {
+            // Parent process: give the VMM some time, then check the exit code.
+            // It should terminate and return 0.
+            sleep(Duration::from_secs(5));
+            wait_vmm_child_process(vmm_pid);
+        }
+    }
 }

--- a/tests/test_build_deps.py
+++ b/tests/test_build_deps.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+"""Test the scripts that build kernel images for the reference VMM."""
+
+import os, subprocess, sys
+import pytest
+from tempfile import TemporaryDirectory
+
+
+# Accepted combinations for:
+# (kernel_format, kernel_filename, halt_flag)
+OK_COMBOS = [
+    ("eLf", None, None),
+    ("elf", "foo", None),
+    ("elf", "foo", True),
+    ("bZiMaGe", None, None),
+    ("bzimage", "bar", None),
+    ("bzimage", "bar", True),
+]
+
+
+# Malformed combinations for:
+# (kernel_format, kernel_filename, halt_flag, expected_error_message)
+BAD_COMBOS = [
+    ("foo", None, None, '[ERROR] Invalid kernel binary format: foo.'),
+]
+
+
+@pytest.mark.parametrize("fmt,img,hlt", OK_COMBOS)
+def test_build_kernel_image(fmt, img, hlt):
+    """Build kernel images using the provided scripts."""
+    workdir = TemporaryDirectory()
+    build_cmd, expected_kernel = _make_script_cmd(workdir.name, fmt, img, hlt)  
+    try:
+        subprocess.run(build_cmd, check=True)
+        assert os.path.isfile(expected_kernel)
+    finally:
+        workdir.cleanup()
+
+
+@pytest.mark.parametrize("fmt,img,hlt,errmsg", BAD_COMBOS)
+def test_build_kernel_image_err(fmt, img, hlt, errmsg):
+    """Attempt to build kernel images with invalid parameters."""
+    workdir = TemporaryDirectory()
+    build_cmd, _ = _make_script_cmd(workdir.name, fmt, img, hlt)  
+    try:
+        subprocess.check_output(build_cmd, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as cpe:
+        assert errmsg in cpe.stderr.decode(sys.getfilesystemencoding())
+    finally:
+        workdir.cleanup()
+
+
+def _make_script_cmd(workdir, fmt, img, hlt):
+    """Compose the command line invocation for the kernel build script."""
+    kernel_dir = "linux-4.14.176"
+    expected_image_path = os.path.join(workdir, kernel_dir)
+
+    script_path = os.path.abspath(os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "..",
+        "resources/kernel/make_kernel_image.sh"
+    ))
+    
+    # Add format. This argument is mandatory.
+    script_cmd = [script_path, "-f", fmt, "-w", workdir]
+    
+    # Add number of CPUs to use for compilation. Not mandatory, but also not
+    # easy to verify, so let's always use 2.
+    script_cmd.extend(["-j", "2"])
+
+    # Add resulting kernel image name, if specified.
+    if img:
+        script_cmd.extend(["-k", img])
+        expected_image_path = os.path.join(expected_image_path, img)
+    else:
+        expected_image_path = os.path.join(
+            expected_image_path,
+            "vmlinux" if fmt.lower() == "elf" else "arch/x86/boot/bzImage"
+        )
+    
+    # Generate a kernel that halts, if specified. The script will append the
+    # "-halt" suffix.
+    if hlt:
+        script_cmd.extend(["-h"])
+        expected_image_path = "{}-halt".format(expected_image_path)
+    
+    return script_cmd, expected_image_path

--- a/tests/test_run_reference_vmm.py
+++ b/tests/test_run_reference_vmm.py
@@ -7,6 +7,9 @@ import pytest
 from subprocess import PIPE, STDOUT
 
 
+KERNELS = ["vmlinux-hello-busybox", "bzimage-hello-busybox"]
+
+
 def process_exists(pid):
     try:
         os.kill(pid, 0)
@@ -16,7 +19,8 @@ def process_exists(pid):
         return True
 
 
-def test_reference_vmm():
+@pytest.mark.parametrize("kernel", KERNELS)
+def test_reference_vmm(kernel):
     """Start the reference VMM and trust that it works."""
 
     # Memory config
@@ -27,7 +31,7 @@ def test_reference_vmm():
     kernel_path = os.path.abspath(os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         "..",
-        "resources/kernel/vmlinux-hello-busybox"
+        "resources/kernel/{}".format(kernel)
     ))
     himem_start = 1048576
 


### PR DESCRIPTION
#20

This PR introduces:
* bzImage changes in the reference VMM: the VMM will always try to load an ELF first, but if the kernel file is not an ELF, it will give bzImage a shot. Boot parameters and rip value are adjusted accordingly.
* revamp of the kernel image builder script: made it more modular, more parameterizable, and capable of baking the busybox initramfs in an ELF as well as a bzImage.
* integration test for the above script: it got complicated, so it kind of needed a test itself. However, the test takes a long time to run because it compiles kernels from scratch for multiple valid parameter combinations, so it's not run by the CI. It will be included in a long running tests battery instead.