### PR TITLE
Add vsock device support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
 ]
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "vm-virtio"
 version = "0.1.0"
-source = "git+https://github.com/alexandruag/vm-virtio.git?branch=proto_wip5#30d1c8dd6487d51bd8e61dea158b3468bd4dff22"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#7803211e914954ced7c5f52773bf9862c97f9a1c"
 dependencies = [
  "byteorder",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "linux-loader"
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "vm-virtio"
 version = "0.1.0"
-source = "git+https://github.com/alexandruag/vm-virtio.git?branch=proto_wip4#e0a0d5dcbdb0c15f5a245934313db6dd2845bb7f"
+source = "git+https://github.com/alexandruag/vm-virtio.git?branch=proto_wip5#30d1c8dd6487d51bd8e61dea158b3468bd4dff22"
 dependencies = [
  "byteorder",
  "libc",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183d25b56a61a6f518ef464ac578e790f04added34dfaab59a453d8a03cb7bd0"
+checksum = "d1cdd1d72e262bbfb014de65ada24c1ac50e10a2e3b1e8ec052df188c2ee5dfa"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ event-manager = { git = "https://github.com/rust-vmm/event-manager.git", rev = "
 linux-loader = { git = "https://github.com/rust-vmm/linux-loader.git", rev ="acf9c21"}
 
 [patch."https://github.com/rust-vmm/vm-virtio.git"]
-vm-virtio = { git = "https://github.com/alexandruag/vm-virtio.git", branch = "proto_wip4" }
+vm-virtio = { git = "https://github.com/alexandruag/vm-virtio.git", branch = "proto_wip5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,3 @@ panic = "abort"
 [patch.crates-io]
 event-manager = { git = "https://github.com/rust-vmm/event-manager.git", rev = "19ddbaa" }
 linux-loader = { git = "https://github.com/rust-vmm/linux-loader.git", rev ="acf9c21"}
-
-[patch."https://github.com/rust-vmm/vm-virtio.git"]
-vm-virtio = { git = "https://github.com/alexandruag/vm-virtio.git", branch = "proto_wip5" }

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 use std::result;
 
 use clap::{App, Arg};
-use vmm::{BlockConfig, KernelConfig, MemoryConfig, NetConfig, VMMConfig, VcpuConfig};
+use vmm::{BlockConfig, KernelConfig, MemoryConfig, NetConfig, VMMConfig, VcpuConfig, VsockConfig};
 
 /// Command line parser.
 pub struct CLI;
@@ -58,6 +58,12 @@ impl CLI {
                     .required(false)
                     .takes_value(true)
                     .help("Block device configuration. \n\tFormat: \"path=<string>\"")
+            )
+            .arg(
+                Arg::with_name("vsock")
+                    .long("vsock")
+                    .takes_value(true)
+                    .help("Vsock device configuration. \n\tFormat: \"cid=<u32>,uds_path=<string>\"")
             );
 
         // Save the usage beforehand as a string, because `get_matches` consumes the `App`.
@@ -111,6 +117,13 @@ impl CLI {
             },
             network_config: match matches.value_of("net") {
                 Some(value) => Some(NetConfig::try_from(value.to_string()).map_err(|e| {
+                    eprintln!("{}", help_msg);
+                    format!("{}", e)
+                })?),
+                None => None,
+            },
+            vsock_config: match matches.value_of("vsock") {
+                Some(value) => Some(VsockConfig::try_from(value.to_string()).map_err(|e| {
                     eprintln!("{}", help_msg);
                     format!("{}", e)
                 })?),

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -12,7 +12,7 @@ libc = "0.2.76"
 linux-loader = "0.2.0"
 log = "0.4.6"
 vm-memory = "0.4.0"
-vmm-sys-util = "0.6.1"
+vmm-sys-util = "0.7.0"
 
 # vm-device is not yet published on crates.io.
 # To make sure that breaking changes to vm-device are not breaking the

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -1,27 +1,22 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+use std::borrow::{Borrow, BorrowMut};
 use std::fs::OpenOptions;
 use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-use event_manager::{MutEventSubscriber, RemoteEndpoint, Result as EvmgrResult, SubscriberId};
-use kvm_ioctls::{IoEventAddress, VmFd};
 use vm_device::bus::MmioAddress;
 use vm_device::device_manager::MmioManager;
 use vm_device::{DeviceMmio, MutDeviceMmio};
-use vm_memory::{GuestAddress, GuestAddressSpace};
+use vm_memory::GuestAddressSpace;
 use vm_virtio::block::stdio_executor::StdIoBackend;
-use vm_virtio::device::{VirtioConfig, VirtioMmioDevice, WithDeviceOps, WithVirtioConfig};
+use vm_virtio::device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
 use vm_virtio::Queue;
-use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
-use crate::virtio::block::{BLOCK_DEVICE_ID, VIRTIO_BLK_F_FLUSH, VIRTIO_BLK_F_RO};
-use crate::virtio::features::{VIRTIO_F_IN_ORDER, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1};
-use crate::virtio::{
-    MmioConfig, SingleFdSignalQueue, QUEUE_MAX_SIZE, VIRTIO_MMIO_QUEUE_NOTIFY_OFFSET,
-};
+use crate::virtio::block::{BLOCK_DEVICE_ID, VIRTIO_BLK_F_RO};
+use crate::virtio::{CommonConfig, Env, SingleFdSignalQueue, QUEUE_MAX_SIZE};
 
 use super::inorder_handler::InOrderQueueHandler;
 use super::queue_handler::QueueHandler;
@@ -31,11 +26,7 @@ use super::{build_config_space, BlockArgs, Error, Result};
 // the functionality when we implement virtio PCI as well, for example by having a base generic
 // type, and then separate concrete instantiations for `MmioConfig` and `PciConfig`.
 pub struct Block<M: GuestAddressSpace> {
-    virtio_cfg: VirtioConfig<M>,
-    mmio_cfg: MmioConfig,
-    endpoint: RemoteEndpoint<Arc<Mutex<dyn MutEventSubscriber + Send>>>,
-    vm_fd: Arc<VmFd>,
-    irqfd: Arc<EventFd>,
+    cfg: CommonConfig<M>,
     file_path: PathBuf,
     read_only: bool,
     // We'll prob need to remember this for state save/restore unless we pass the info from
@@ -47,149 +38,76 @@ impl<M> Block<M>
 where
     M: GuestAddressSpace + Clone + Send + 'static,
 {
-    pub fn new<B>(mut args: BlockArgs<M, B>) -> Result<Arc<Mutex<Self>>>
+    // Helper method that only creates a `Block` object.
+    fn create_block<B>(env: &mut Env<M, B>, args: &BlockArgs) -> Result<Self> {
+        let device_features = args.device_features();
+
+        // A block device has a single queue.
+        let queues = vec![Queue::new(env.mem.clone(), QUEUE_MAX_SIZE)];
+        let config_space = build_config_space(&args.file_path)?;
+        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
+
+        let common_cfg = CommonConfig::new(virtio_cfg, env).map_err(Error::Generic)?;
+
+        Ok(Block {
+            cfg: common_cfg,
+            file_path: args.file_path.clone(),
+            read_only: args.read_only,
+            _root_device: args.root_device,
+        })
+    }
+
+    // Create `Block` object, register it on the MMIO bus, and add any extra required info to
+    // the kernel cmdline from the environment.
+    pub fn new<B>(env: &mut Env<M, B>, args: &BlockArgs) -> Result<Arc<Mutex<Self>>>
     where
         // We're using this (more convoluted) bound so we can pass both references and smart
         // pointers such as mutex guards here.
         B: DerefMut,
         B::Target: MmioManager<D = Arc<dyn DeviceMmio + Send + Sync>>,
     {
-        // The queue handling logic for this device uses the buffers in order, so we enable the
-        // corresponding feature as well.
-        let mut device_features =
-            1 << VIRTIO_F_VERSION_1 | 1 << VIRTIO_F_IN_ORDER | 1 << VIRTIO_F_RING_EVENT_IDX;
-
-        if args.read_only {
-            device_features |= 1 << VIRTIO_BLK_F_RO;
-        }
-
-        if args.advertise_flush {
-            device_features |= 1 << VIRTIO_BLK_F_FLUSH;
-        }
-
-        // A block device has a single queue.
-        let queues = vec![Queue::new(args.common.mem, QUEUE_MAX_SIZE)];
-        let config_space = build_config_space(&args.file_path)?;
-        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
-
-        // Used to send notifications to the driver.
-        let irqfd = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
-
-        args.common
-            .vm_fd
-            .register_irqfd(&irqfd, args.common.mmio_cfg.gsi)
-            .map_err(Error::RegisterIrqfd)?;
-
-        let mmio_cfg = args.common.mmio_cfg;
-
-        let block = Arc::new(Mutex::new(Block {
-            virtio_cfg,
-            mmio_cfg,
-            endpoint: args.common.event_mgr.remote_endpoint(),
-            vm_fd: args.common.vm_fd,
-            irqfd: Arc::new(irqfd),
-            file_path: args.file_path,
-            read_only: args.read_only,
-            _root_device: args.root_device,
-        }));
+        let block = Arc::new(Mutex::new(Self::create_block(env, args)?));
 
         // Register the device on the MMIO bus.
-        args.common
-            .mmio_mgr
-            .register_mmio(mmio_cfg.range, block.clone())
-            .map_err(Error::Bus)?;
+        env.register_mmio_device(block.clone())
+            .map_err(Error::Generic)?;
 
-        // Extra parameters have to be appended to the cmdline passed to the kernel because
-        // there's no active enumeration/discovery mechanism for virtio over MMIO. In the future,
-        // we might rely on a device tree representation instead.
-
-        args.common
-            .kernel_cmdline
-            .add_virtio_mmio_device(
-                mmio_cfg.range.size(),
-                GuestAddress(mmio_cfg.range.base().0),
-                mmio_cfg.gsi,
-                None,
-            )
-            .map_err(Error::Cmdline)?;
-
-        if args.root_device {
-            args.common
-                .kernel_cmdline
-                .insert_str("root=/dev/vda")
-                .map_err(Error::Cmdline)?;
-
-            if args.read_only {
-                args.common
-                    .kernel_cmdline
-                    .insert_str("ro")
-                    .map_err(Error::Cmdline)?;
-            }
-        }
+        env.insert_cmdline_str(args.cmdline_string())
+            .map_err(Error::Generic)?;
 
         Ok(block)
     }
 }
 
-// We now implement `WithVirtioConfig` and `WithDeviceOps` to get the automatic implementation
-// for `VirtioDevice`.
-impl<M: GuestAddressSpace + Clone + Send + 'static> WithVirtioConfig<M> for Block<M> {
-    fn device_type(&self) -> u32 {
-        BLOCK_DEVICE_ID
-    }
-
-    fn virtio_config(&self) -> &VirtioConfig<M> {
-        &self.virtio_cfg
-    }
-
-    fn virtio_config_mut(&mut self) -> &mut VirtioConfig<M> {
-        &mut self.virtio_cfg
+impl<M: GuestAddressSpace + Clone + Send + 'static> Borrow<VirtioConfig<M>> for Block<M> {
+    fn borrow(&self) -> &VirtioConfig<M> {
+        &self.cfg.virtio
     }
 }
 
-impl<M: GuestAddressSpace + Clone + Send + 'static> WithDeviceOps for Block<M> {
+impl<M: GuestAddressSpace + Clone + Send + 'static> BorrowMut<VirtioConfig<M>> for Block<M> {
+    fn borrow_mut(&mut self) -> &mut VirtioConfig<M> {
+        &mut self.cfg.virtio
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceType for Block<M> {
+    fn device_type(&self) -> u32 {
+        BLOCK_DEVICE_ID
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Block<M> {
     type E = Error;
 
     fn activate(&mut self) -> Result<()> {
-        if self.virtio_cfg.device_activated {
-            return Err(Error::AlreadyActivated);
-        }
-
-        if !self.queues_valid() {
-            return Err(Error::QueuesNotValid);
-        }
-
-        // We do not support legacy drivers.
-        if self.virtio_cfg.driver_features & (1 << VIRTIO_F_VERSION_1) == 0 {
-            return Err(Error::BadFeatures(self.virtio_cfg.driver_features));
-        }
-
-        // Set the appropriate queue configuration flag if the `EVENT_IDX` features has been
-        // negotiated.
-        if self.virtio_cfg.driver_features & (1 << VIRTIO_F_RING_EVENT_IDX) != 0 {
-            self.virtio_cfg.queues[0].set_event_idx(true);
-        }
-
-        let ioeventfd = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
-
-        // Register the queue event fd.
-        self.vm_fd
-            .register_ioevent(
-                &ioeventfd,
-                &IoEventAddress::Mmio(
-                    self.mmio_cfg.range.base().0 + VIRTIO_MMIO_QUEUE_NOTIFY_OFFSET,
-                ),
-                0u32,
-            )
-            .map_err(Error::RegisterIoevent)?;
-
         let file = OpenOptions::new()
             .read(true)
             .write(!self.read_only)
             .open(&self.file_path)
             .map_err(Error::OpenFile)?;
 
-        let mut features = self.virtio_cfg.driver_features;
+        let mut features = self.cfg.virtio.driver_features;
         if self.read_only {
             // Not sure if the driver is expected to explicitly acknowledge the `RO` feature,
             // so adding it explicitly here when present just in case.
@@ -200,31 +118,24 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> WithDeviceOps for Block<M> {
         let disk = StdIoBackend::new(file, features).map_err(Error::Backend)?;
 
         let driver_notify = SingleFdSignalQueue {
-            irqfd: self.irqfd.clone(),
-            interrupt_status: self.virtio_cfg.interrupt_status.clone(),
+            irqfd: self.cfg.irqfd.clone(),
+            interrupt_status: self.cfg.virtio.interrupt_status.clone(),
         };
 
         let inner = InOrderQueueHandler {
             driver_notify,
-            queue: self.virtio_cfg.queues[0].clone(),
+            queue: self.cfg.virtio.queues[0].clone(),
             disk,
         };
 
-        let handler = Arc::new(Mutex::new(QueueHandler { inner, ioeventfd }));
+        let mut ioevents = self.cfg.prepare_activate().map_err(Error::Generic)?;
 
-        // Register the queue handler with the `EventManager`. We could record the `sub_id`
-        // (and/or keep a handler clone) for further interaction (i.e. to remove the subscriber at
-        // a later time, retrieve state, etc).
-        let _sub_id = self
-            .endpoint
-            .call_blocking(move |mgr| -> EvmgrResult<SubscriberId> {
-                Ok(mgr.add_subscriber(handler))
-            })
-            .map_err(Error::Endpoint)?;
+        let handler = Arc::new(Mutex::new(QueueHandler {
+            inner,
+            ioeventfd: ioevents.remove(0),
+        }));
 
-        self.virtio_cfg.device_activated = true;
-
-        Ok(())
+        self.cfg.finalize_activate(handler).map_err(Error::Generic)
     }
 
     fn reset(&mut self) -> Result<()> {
@@ -249,127 +160,45 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> MutDeviceMmio for Block<M> {
 mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
-    use crate::virtio::tests::CommonArgsMock;
+    use crate::virtio::tests::EnvMock;
 
+    use super::super::VIRTIO_BLK_F_FLUSH;
     use super::*;
 
     // Restricting this for now, because registering irqfds does not work on Arm without properly
-    // setting up the equivalent of the irqchip first (as part of `CommonArgsContext::new`).
+    // setting up the equivalent of the irqchip first (as part of `EnvMock::new`).
     #[cfg_attr(target_arch = "aarch64", ignore)]
     #[test]
     fn test_device() {
         let tmp = TempFile::new().unwrap();
 
-        {
-            let mut mock = CommonArgsMock::new();
-            let common_args = mock.args();
-            let args = BlockArgs {
-                common: common_args,
-                file_path: tmp.as_path().to_path_buf(),
-                read_only: false,
-                root_device: true,
-                advertise_flush: true,
-            };
+        let mut mock = EnvMock::new();
+        let mut env = mock.env();
+        let args = BlockArgs {
+            file_path: tmp.as_path().to_path_buf(),
+            read_only: true,
+            root_device: true,
+            advertise_flush: true,
+        };
 
-            let block_mutex = Block::new(args).unwrap();
-            let mut block = block_mutex.lock().unwrap();
+        let block_mutex = Block::new(&mut env, &args).unwrap();
+        let block = block_mutex.lock().unwrap();
 
-            // The read-only feature should not be present.
-            assert_eq!(block.virtio_cfg.device_features & (1 << VIRTIO_BLK_F_RO), 0);
-            // The flush feature should be present.
-            assert_ne!(
-                block.virtio_cfg.device_features & (1 << VIRTIO_BLK_F_FLUSH),
-                0
-            );
+        assert_eq!(block.device_type(), BLOCK_DEVICE_ID);
 
-            // Some quick sanity checks. Most of the functionality around the device should be
-            // exercised/validated via integration tests.
+        assert_eq!(
+            mock.kernel_cmdline.as_str(),
+            format!(
+                "virtio_mmio.device=4K@0x{:x}:{} root=/dev/vda ro",
+                mock.mmio_cfg.range.base().0,
+                mock.mmio_cfg.gsi
+            )
+        );
 
-            let range = mock.mmio_cfg.range;
-
-            let bus_range = mock.mmio_mgr.mmio_device(range.base()).unwrap().0;
-            assert_eq!(bus_range.base(), range.base());
-            assert_eq!(bus_range.size(), range.size());
-
-            assert_eq!(
-                mock.kernel_cmdline.as_str(),
-                format!(
-                    "virtio_mmio.device=4K@0x{:x}:{} root=/dev/vda",
-                    range.base().0,
-                    mock.mmio_cfg.gsi
-                )
-            );
-
-            assert_eq!(block.device_type(), BLOCK_DEVICE_ID);
-
-            assert!(matches!(block.activate(), Err(Error::QueuesNotValid)));
-
-            block.virtio_config_mut().device_activated = true;
-            assert_eq!(block.virtio_config().device_activated, true);
-            assert!(matches!(block.activate(), Err(Error::AlreadyActivated)));
-        }
-
-        // Test a read-only root device.
-        {
-            let mut mock = CommonArgsMock::new();
-            let common_args = mock.args();
-            let args = BlockArgs {
-                common: common_args,
-                file_path: tmp.as_path().to_path_buf(),
-                read_only: true,
-                root_device: true,
-                advertise_flush: true,
-            };
-
-            let block_mutex = Block::new(args).unwrap();
-            let block = block_mutex.lock().unwrap();
-
-            // The read-only feature should be present.
-            assert_ne!(block.virtio_cfg.device_features & (1 << VIRTIO_BLK_F_RO), 0);
-
-            assert_eq!(
-                mock.kernel_cmdline.as_str(),
-                format!(
-                    "virtio_mmio.device=4K@0x{:x}:{} root=/dev/vda ro",
-                    mock.mmio_cfg.range.base().0,
-                    mock.mmio_cfg.gsi
-                )
-            );
-        }
-
-        // Test a block device with root and advertise flush not enabled.
-        {
-            {
-                let mut mock = CommonArgsMock::new();
-                let common_args = mock.args();
-                let args = BlockArgs {
-                    common: common_args,
-                    file_path: tmp.as_path().to_path_buf(),
-                    read_only: true,
-                    root_device: false,
-                    advertise_flush: false,
-                };
-
-                let block_mutex = Block::new(args).unwrap();
-                let block = block_mutex.lock().unwrap();
-
-                // The read-only feature should be present.
-                assert_ne!(block.virtio_cfg.device_features & (1 << VIRTIO_BLK_F_RO), 0);
-                // The flush feature should not be present.
-                assert_eq!(
-                    block.virtio_cfg.device_features & (1 << VIRTIO_BLK_F_FLUSH),
-                    0
-                );
-
-                assert_eq!(
-                    mock.kernel_cmdline.as_str(),
-                    format!(
-                        "virtio_mmio.device=4K@0x{:x}:{}",
-                        mock.mmio_cfg.range.base().0,
-                        mock.mmio_cfg.gsi
-                    )
-                );
-            }
-        }
+        assert_ne!(block.cfg.virtio.device_features & (1 << VIRTIO_BLK_F_RO), 0);
+        assert_ne!(
+            block.cfg.virtio.device_features & (1 << VIRTIO_BLK_F_FLUSH),
+            0
+        );
     }
 }

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -9,12 +9,9 @@ use std::fs::File;
 use std::io::{self, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
-use event_manager::Error as EvmgrError;
-use vm_device::bus;
 use vm_virtio::block::stdio_executor;
-use vmm_sys_util::errno;
 
-use crate::virtio::CommonArgs;
+use crate::virtio::features::{VIRTIO_F_IN_ORDER, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1};
 
 pub use device::Block;
 
@@ -33,17 +30,9 @@ const SECTOR_SHIFT: u8 = 9;
 
 #[derive(Debug)]
 pub enum Error {
-    AlreadyActivated,
     Backend(stdio_executor::Error),
-    BadFeatures(u64),
-    Bus(bus::Error),
-    Cmdline(linux_loader::cmdline::Error),
-    Endpoint(EvmgrError),
-    EventFd(io::Error),
+    Generic(crate::virtio::Error),
     OpenFile(io::Error),
-    QueuesNotValid,
-    RegisterIoevent(errno::Error),
-    RegisterIrqfd(errno::Error),
     Seek(io::Error),
 }
 
@@ -67,12 +56,45 @@ fn build_config_space<P: AsRef<Path>>(path: P) -> Result<Vec<u8>> {
 }
 
 // Arguments required when building a block device.
-pub struct BlockArgs<'a, M, B> {
-    pub common: CommonArgs<'a, M, B>,
+pub struct BlockArgs {
     pub file_path: PathBuf,
     pub read_only: bool,
     pub root_device: bool,
     pub advertise_flush: bool,
+}
+
+impl BlockArgs {
+    // Generate device features based on the configuration options.
+    pub fn device_features(&self) -> u64 {
+        // The queue handling logic for the device uses the buffers in order, so we enable the
+        // corresponding feature as well.
+        let mut features =
+            1 << VIRTIO_F_VERSION_1 | 1 << VIRTIO_F_IN_ORDER | 1 << VIRTIO_F_RING_EVENT_IDX;
+
+        if self.read_only {
+            features |= 1 << VIRTIO_BLK_F_RO;
+        }
+
+        if self.advertise_flush {
+            features |= 1 << VIRTIO_BLK_F_FLUSH;
+        }
+
+        features
+    }
+
+    // Generate additional info that needs to be appended to the kernel command line based
+    // on the current arg configuration.
+    pub fn cmdline_string(&self) -> String {
+        let mut s = String::new();
+        if self.root_device {
+            s.push_str("root=/dev/vda");
+
+            if self.read_only {
+                s.push_str(" ro");
+            }
+        }
+        s
+    }
 }
 
 #[cfg(test)]
@@ -83,6 +105,17 @@ mod tests {
     use vmm_sys_util::tempfile::TempFile;
 
     use super::*;
+
+    impl Default for BlockArgs {
+        fn default() -> Self {
+            BlockArgs {
+                file_path: "".into(),
+                read_only: false,
+                root_device: false,
+                advertise_flush: false,
+            }
+        }
+    }
 
     #[test]
     fn test_build_config_space() {
@@ -112,5 +145,39 @@ mod tests {
             // We should get the same value of capacity, as the extra bytes are ignored.
             assert_eq!(config_space[..8], num_sectors.to_le_bytes());
         }
+    }
+
+    #[test]
+    fn test_device_features() {
+        let mut args = BlockArgs::default();
+
+        let base =
+            1u64 << VIRTIO_F_VERSION_1 | 1 << VIRTIO_F_IN_ORDER | 1 << VIRTIO_F_RING_EVENT_IDX;
+
+        assert_eq!(args.device_features(), base);
+
+        args.read_only = true;
+        assert_eq!(args.device_features(), base | 1 << VIRTIO_BLK_F_RO);
+
+        args.read_only = false;
+        args.advertise_flush = true;
+        assert_eq!(args.device_features(), base | 1 << VIRTIO_BLK_F_FLUSH);
+    }
+
+    #[test]
+    fn test_cmdline_string() {
+        let mut args = BlockArgs::default();
+
+        assert_eq!(args.cmdline_string(), "");
+
+        args.read_only = true;
+        // There's no effect unless `root_device` is also `true`.
+        assert_eq!(args.cmdline_string(), "");
+
+        args.root_device = true;
+        assert_eq!(args.cmdline_string(), "root=/dev/vda ro");
+
+        args.read_only = false;
+        assert_eq!(args.cmdline_string(), "root=/dev/vda");
     }
 }

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -5,14 +5,25 @@
 
 pub mod block;
 
+use std::convert::TryFrom;
+use std::io;
+use std::ops::DerefMut;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 
-use event_manager::{EventManager, MutEventSubscriber};
-use kvm_ioctls::VmFd;
+use event_manager::{
+    Error as EvmgrError, EventManager, MutEventSubscriber, RemoteEndpoint, Result as EvmgrResult,
+    SubscriberId,
+};
+use kvm_ioctls::{IoEventAddress, VmFd};
 use linux_loader::cmdline::Cmdline;
-use vm_device::bus::MmioRange;
-use vmm_sys_util::eventfd::EventFd;
+use vm_device::bus::{self, MmioRange};
+use vm_device::device_manager::MmioManager;
+use vm_device::DeviceMmio;
+use vm_memory::{GuestAddress, GuestAddressSpace};
+use vm_virtio::device::VirtioConfig;
+use vmm_sys_util::errno;
+use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
 // TODO: Move virtio-related defines from the local modules to the `vm-virtio` crate upstream.
 
@@ -38,6 +49,23 @@ const VIRTIO_MMIO_QUEUE_NOTIFY_OFFSET: u64 = 0x50;
 // TODO: Make configurable for each device maybe?
 const QUEUE_MAX_SIZE: u16 = 256;
 
+// Common errors encountered during device creation, configuration, and operation.
+#[derive(Debug)]
+pub enum Error {
+    AlreadyActivated,
+    BadFeatures(u64),
+    Bus(bus::Error),
+    Cmdline(linux_loader::cmdline::Error),
+    Endpoint(EvmgrError),
+    EventFd(io::Error),
+    QueuesNotValid,
+    RegisterIoevent(errno::Error),
+    RegisterIrqfd(errno::Error),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+pub type Subscriber = Arc<Mutex<dyn MutEventSubscriber + Send>>;
+
 #[derive(Copy, Clone)]
 pub struct MmioConfig {
     pub range: MmioRange,
@@ -45,9 +73,11 @@ pub struct MmioConfig {
     pub gsi: u32,
 }
 
-// These arguments are common for all virtio devices. We're always passing a mmio_cfg object
-// for now, and we'll re-evaluate the layout of this struct when adding more transport options.
-pub struct CommonArgs<'a, M, B> {
+// Represents the environment the devices in this crate current expect in order to be created
+// and registered with the appropriate buses/handlers/etc. We're always passing a mmio_cfg object
+// for now, and we'll re-evaluate the mechanism for exposing environment (i.e. maybe we'll do it
+// through an object that implements a number of traits the devices are aware of).
+pub struct Env<'a, M, B> {
     // The objects used for guest memory accesses and other operations.
     pub mem: M,
     // Used by the devices to register ioevents and irqfds.
@@ -65,6 +95,132 @@ pub struct CommonArgs<'a, M, B> {
     // the devices before loading he kernel cmdline into memory, but that's not a significant
     // limitation.
     pub kernel_cmdline: &'a mut Cmdline,
+}
+
+impl<'a, M, B> Env<'a, M, B>
+where
+    // We're using this (more convoluted) bound so we can pass both references and smart
+    // pointers such as mutex guards here.
+    B: DerefMut,
+    B::Target: MmioManager<D = Arc<dyn DeviceMmio + Send + Sync>>,
+{
+    // Registers an MMIO device with the inner bus and kernel cmdline.
+    pub fn register_mmio_device(
+        &mut self,
+        device: Arc<dyn DeviceMmio + Send + Sync>,
+    ) -> Result<()> {
+        self.mmio_mgr
+            .register_mmio(self.mmio_cfg.range, device)
+            .map_err(Error::Bus)?;
+
+        self.kernel_cmdline
+            .add_virtio_mmio_device(
+                self.mmio_cfg.range.size(),
+                GuestAddress(self.mmio_cfg.range.base().0),
+                self.mmio_cfg.gsi,
+                None,
+            )
+            .map_err(Error::Cmdline)?;
+
+        Ok(())
+    }
+
+    // Appends a string to the inner kernel cmdline.
+    pub fn insert_cmdline_str<T: AsRef<str>>(&mut self, t: T) -> Result<()> {
+        self.kernel_cmdline
+            .insert_str(t.as_ref())
+            .map_err(Error::Cmdline)
+    }
+}
+
+// Holds configuration objects which are common to all current devices.
+pub struct CommonConfig<M: GuestAddressSpace> {
+    pub virtio: VirtioConfig<M>,
+    pub mmio: MmioConfig,
+    pub endpoint: RemoteEndpoint<Subscriber>,
+    pub vm_fd: Arc<VmFd>,
+    pub irqfd: Arc<EventFd>,
+}
+
+impl<M: GuestAddressSpace> CommonConfig<M> {
+    pub fn new<B>(virtio_cfg: VirtioConfig<M>, env: &Env<M, B>) -> Result<Self> {
+        let irqfd = Arc::new(EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?);
+
+        env.vm_fd
+            .register_irqfd(&irqfd, env.mmio_cfg.gsi)
+            .map_err(Error::RegisterIrqfd)?;
+
+        Ok(CommonConfig {
+            virtio: virtio_cfg,
+            mmio: env.mmio_cfg,
+            endpoint: env.event_mgr.remote_endpoint(),
+            vm_fd: env.vm_fd.clone(),
+            irqfd,
+        })
+    }
+
+    // Perform common initial steps for device activation based on the configuration, and return
+    // a `Vec` that contains `EventFd`s registered as ioeventfds, which are used to convey queue
+    // notifications coming from the driver.
+    pub fn prepare_activate(&self) -> Result<Vec<EventFd>> {
+        if !self.virtio.queues_valid() {
+            return Err(Error::QueuesNotValid);
+        }
+
+        if self.virtio.device_activated {
+            return Err(Error::AlreadyActivated);
+        }
+
+        // We do not support legacy drivers.
+        if self.virtio.driver_features & (1 << features::VIRTIO_F_VERSION_1) == 0 {
+            return Err(Error::BadFeatures(self.virtio.driver_features));
+        }
+
+        let mut ioevents = Vec::new();
+
+        // Right now, we operate under the assumption all queues are marked ready by the device
+        // (which is true until we start supporting devices that can optionally make use of
+        // additional queues on top of the defaults).
+        for i in 0..self.virtio.queues.len() {
+            let fd = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
+
+            // Register the queue event fd.
+            self.vm_fd
+                .register_ioevent(
+                    &fd,
+                    &IoEventAddress::Mmio(
+                        self.mmio.range.base().0 + VIRTIO_MMIO_QUEUE_NOTIFY_OFFSET,
+                    ),
+                    // The maximum number of queues should fit within an `u16` according to the
+                    // standard, so the conversion below is always expected to succeed.
+                    u32::try_from(i).unwrap(),
+                )
+                .map_err(Error::RegisterIoevent)?;
+
+            ioevents.push(fd);
+        }
+
+        Ok(ioevents)
+    }
+
+    // Perform the final steps of device activation based on the inner configuration and the
+    // provided subscriber that's going to handle the device queues. We'll extend this when
+    // we start support devices that make use of multiple handlers (i.e. for multiple queues).
+    pub fn finalize_activate(&mut self, handler: Subscriber) -> Result<()> {
+        // Register the queue handler with the `EventManager`. We could record the `sub_id`
+        // (and/or keep a handler clone) for further interaction (i.e. to remove the subscriber at
+        // a later time, retrieve state, etc).
+        let _sub_id = self
+            .endpoint
+            .call_blocking(move |mgr| -> EvmgrResult<SubscriberId> {
+                Ok(mgr.add_subscriber(handler))
+            })
+            .map_err(Error::Endpoint)?;
+
+        self.virtio.device_activated = true;
+
+        Ok(())
+    }
 }
 
 /// Simple trait to model the operation of signalling the driver about used events
@@ -97,8 +253,13 @@ impl SignalUsedQueue for SingleFdSignalQueue {
 pub(crate) mod tests {
     use vm_device::bus::MmioAddress;
     use vm_device::device_manager::IoManager;
+    use vm_device::MutDeviceMmio;
     use vm_memory::{GuestAddress, GuestMemoryMmap};
 
+    use event_manager::{EventOps, Events};
+    use vm_virtio::Queue;
+
+    use super::features::VIRTIO_F_VERSION_1;
     use super::*;
 
     pub type MockMem = Arc<GuestMemoryMmap>;
@@ -106,7 +267,7 @@ pub(crate) mod tests {
     // Can be used in other modules to test functionality that requires a `CommonArgs` struct as
     // input. The `args` method below generates an instance of `CommonArgs` based on the members
     // below.
-    pub struct CommonArgsMock {
+    pub struct EnvMock {
         pub mem: MockMem,
         pub vm_fd: Arc<VmFd>,
         pub event_mgr: EventManager<Arc<Mutex<dyn MutEventSubscriber + Send>>>,
@@ -115,7 +276,7 @@ pub(crate) mod tests {
         pub kernel_cmdline: Cmdline,
     }
 
-    impl CommonArgsMock {
+    impl EnvMock {
         pub fn new() -> Self {
             let mem =
                 Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000_0000)]).unwrap());
@@ -129,7 +290,7 @@ pub(crate) mod tests {
             // Required so the vm_fd can be used to register irqfds.
             vm_fd.create_irq_chip().unwrap();
 
-            CommonArgsMock {
+            EnvMock {
                 mem,
                 vm_fd,
                 event_mgr: EventManager::new().unwrap(),
@@ -140,8 +301,8 @@ pub(crate) mod tests {
             }
         }
 
-        pub fn args(&mut self) -> CommonArgs<MockMem, &mut IoManager> {
-            CommonArgs {
+        pub fn env(&mut self) -> Env<MockMem, &mut IoManager> {
+            Env {
                 mem: self.mem.clone(),
                 vm_fd: self.vm_fd.clone(),
                 event_mgr: &mut self.event_mgr,
@@ -150,5 +311,97 @@ pub(crate) mod tests {
                 kernel_cmdline: &mut self.kernel_cmdline,
             }
         }
+    }
+
+    #[test]
+    fn test_env() {
+        // Just a dummy device we're going to register on the bus.
+        struct Dummy;
+
+        impl MutDeviceMmio for Dummy {
+            fn mmio_read(&mut self, _base: MmioAddress, _offset: u64, _data: &mut [u8]) {}
+
+            fn mmio_write(&mut self, _base: MmioAddress, _offset: u64, _data: &[u8]) {}
+        }
+
+        let mut mock = EnvMock::new();
+
+        let dummy = Arc::new(Mutex::new(Dummy));
+
+        mock.env().register_mmio_device(dummy).unwrap();
+
+        let range = mock.mmio_cfg.range;
+        let bus_range = mock.mmio_mgr.mmio_device(range.base()).unwrap().0;
+        assert_eq!(bus_range.base(), range.base());
+        assert_eq!(bus_range.size(), range.size());
+
+        assert_eq!(
+            mock.kernel_cmdline.as_str(),
+            format!(
+                "virtio_mmio.device=4K@0x{:x}:{}",
+                range.base().0,
+                mock.mmio_cfg.gsi
+            )
+        );
+
+        mock.env().insert_cmdline_str("ending_string").unwrap();
+        assert!(mock.kernel_cmdline.as_str().ends_with("ending_string"));
+    }
+
+    #[test]
+    fn test_common_config() {
+        let mut mock = EnvMock::new();
+        let env = mock.env();
+
+        let device_features = 0;
+        let queues = vec![Queue::new(env.mem.clone(), 256)];
+        let config_space = Vec::new();
+        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
+
+        let mut cfg = CommonConfig::new(virtio_cfg, &env).unwrap();
+        assert_eq!(cfg.virtio.device_activated, false);
+
+        assert!(matches!(cfg.prepare_activate(), Err(Error::QueuesNotValid)));
+
+        // Let's pretend the queue has been configured such that the `is_valid` check passes.
+        cfg.virtio.queues[0].ready = true;
+        cfg.virtio.queues[0].size = 256;
+
+        // This will fail because the "driver" didn't acknowledge `VIRTIO_F_VERSION_1`.
+        assert!(matches!(cfg.prepare_activate(), Err(Error::BadFeatures(0))));
+
+        cfg.virtio.driver_features = 1 << VIRTIO_F_VERSION_1;
+
+        cfg.virtio.device_activated = true;
+        assert!(matches!(
+            cfg.prepare_activate(),
+            Err(Error::AlreadyActivated)
+        ));
+
+        cfg.virtio.device_activated = false;
+        let ioevents = cfg.prepare_activate().unwrap();
+        assert_eq!(ioevents.len(), cfg.virtio.queues.len());
+
+        // Let's define a dummy subscriber to invoke `finalize_activate`.
+        struct Dummy;
+
+        impl MutEventSubscriber for Dummy {
+            fn process(&mut self, _events: Events, _ops: &mut EventOps) {}
+
+            fn init(&mut self, _ops: &mut EventOps) {}
+        }
+
+        // `finalize_activate` attempts to register the subscriber using a remote endpoint and
+        // the associated `call_blocking` method, so let's start up a separate thread while
+        // waiting for one `EventManager` run loop to finish on the current one.
+
+        let t = std::thread::spawn(move || {
+            cfg.finalize_activate(Arc::new(Mutex::new(Dummy))).unwrap();
+            assert_eq!(cfg.virtio.device_activated, true);
+        });
+
+        assert_eq!(mock.event_mgr.run(), Ok(1));
+
+        t.join().unwrap();
     }
 }

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod block;
 pub mod net;
+pub mod vsock;
 
 use std::convert::TryFrom;
 use std::io;

--- a/src/devices/src/virtio/net/bindings.rs
+++ b/src/devices/src/virtio/net/bindings.rs
@@ -1,0 +1,269 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+// The following are manually copied from crosvm/firecracker. In the latter, they can be found as
+// part of the `net_gen` local crate. We should figure out how to proceed going forward (i.e.
+// create some bindings of our own, put them in a common crate, etc).
+
+#![allow(clippy::all)]
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+pub const TUN_F_CSUM: ::std::os::raw::c_uint = 1;
+pub const TUN_F_TSO4: ::std::os::raw::c_uint = 2;
+pub const TUN_F_TSO6: ::std::os::raw::c_uint = 4;
+pub const TUN_F_UFO: ::std::os::raw::c_uint = 16;
+
+#[repr(C)]
+pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+impl<T> __BindgenUnionField<T> {
+    #[inline]
+    pub fn new() -> Self {
+        __BindgenUnionField(::std::marker::PhantomData)
+    }
+    #[inline]
+    pub unsafe fn as_ref(&self) -> &T {
+        ::std::mem::transmute(self)
+    }
+    #[inline]
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        ::std::mem::transmute(self)
+    }
+}
+impl<T> ::std::default::Default for __BindgenUnionField<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self::new()
+    }
+}
+impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        fmt.write_str("__BindgenUnionField")
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct ifreq {
+    pub ifr_ifrn: ifreq__bindgen_ty_1,
+    pub ifr_ifru: ifreq__bindgen_ty_2,
+}
+
+impl Clone for ifreq {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct ifreq__bindgen_ty_1 {
+    pub ifrn_name: __BindgenUnionField<[::std::os::raw::c_uchar; 16usize]>,
+    pub bindgen_union_field: [u8; 16usize],
+}
+
+impl Clone for ifreq__bindgen_ty_1 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct ifreq__bindgen_ty_2 {
+    pub ifru_addr: __BindgenUnionField<sockaddr>,
+    pub ifru_dstaddr: __BindgenUnionField<sockaddr>,
+    pub ifru_broadaddr: __BindgenUnionField<sockaddr>,
+    pub ifru_netmask: __BindgenUnionField<sockaddr>,
+    pub ifru_hwaddr: __BindgenUnionField<sockaddr>,
+    pub ifru_flags: __BindgenUnionField<::std::os::raw::c_short>,
+    pub ifru_ivalue: __BindgenUnionField<::std::os::raw::c_int>,
+    pub ifru_mtu: __BindgenUnionField<::std::os::raw::c_int>,
+    pub ifru_map: __BindgenUnionField<ifmap>,
+    pub ifru_slave: __BindgenUnionField<[::std::os::raw::c_char; 16usize]>,
+    pub ifru_newname: __BindgenUnionField<[::std::os::raw::c_char; 16usize]>,
+    pub ifru_data: __BindgenUnionField<*mut ::std::os::raw::c_void>,
+    pub ifru_settings: __BindgenUnionField<if_settings>,
+    pub bindgen_union_field: [u64; 3usize],
+}
+
+impl Clone for ifreq__bindgen_ty_2 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+pub type sa_family_t = ::std::os::raw::c_ushort;
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct sockaddr {
+    pub sa_family: sa_family_t,
+    pub sa_data: [::std::os::raw::c_char; 14usize],
+}
+
+impl Clone for sockaddr {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct if_settings {
+    pub type_: ::std::os::raw::c_uint,
+    pub size: ::std::os::raw::c_uint,
+    pub ifs_ifsu: if_settings__bindgen_ty_1,
+}
+
+impl Clone for if_settings {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct if_settings__bindgen_ty_1 {
+    pub raw_hdlc: __BindgenUnionField<*mut raw_hdlc_proto>,
+    pub cisco: __BindgenUnionField<*mut cisco_proto>,
+    pub fr: __BindgenUnionField<*mut fr_proto>,
+    pub fr_pvc: __BindgenUnionField<*mut fr_proto_pvc>,
+    pub fr_pvc_info: __BindgenUnionField<*mut fr_proto_pvc_info>,
+    pub sync: __BindgenUnionField<*mut sync_serial_settings>,
+    pub te1: __BindgenUnionField<*mut te1_settings>,
+    pub bindgen_union_field: u64,
+}
+
+impl Clone for if_settings__bindgen_ty_1 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct ifmap {
+    pub mem_start: ::std::os::raw::c_ulong,
+    pub mem_end: ::std::os::raw::c_ulong,
+    pub base_addr: ::std::os::raw::c_ushort,
+    pub irq: ::std::os::raw::c_uchar,
+    pub dma: ::std::os::raw::c_uchar,
+    pub port: ::std::os::raw::c_uchar,
+}
+
+impl Clone for ifmap {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct raw_hdlc_proto {
+    pub encoding: ::std::os::raw::c_ushort,
+    pub parity: ::std::os::raw::c_ushort,
+}
+
+impl Clone for raw_hdlc_proto {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct cisco_proto {
+    pub interval: ::std::os::raw::c_uint,
+    pub timeout: ::std::os::raw::c_uint,
+}
+
+impl Clone for cisco_proto {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct fr_proto {
+    pub t391: ::std::os::raw::c_uint,
+    pub t392: ::std::os::raw::c_uint,
+    pub n391: ::std::os::raw::c_uint,
+    pub n392: ::std::os::raw::c_uint,
+    pub n393: ::std::os::raw::c_uint,
+    pub lmi: ::std::os::raw::c_ushort,
+    pub dce: ::std::os::raw::c_ushort,
+}
+
+impl Clone for fr_proto {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct fr_proto_pvc {
+    pub dlci: ::std::os::raw::c_uint,
+}
+
+impl Clone for fr_proto_pvc {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct fr_proto_pvc_info {
+    pub dlci: ::std::os::raw::c_uint,
+    pub master: [::std::os::raw::c_char; 16usize],
+}
+
+impl Clone for fr_proto_pvc_info {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct sync_serial_settings {
+    pub clock_rate: ::std::os::raw::c_uint,
+    pub clock_type: ::std::os::raw::c_uint,
+    pub loopback: ::std::os::raw::c_ushort,
+}
+
+impl Clone for sync_serial_settings {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Default, Copy)]
+pub struct te1_settings {
+    pub clock_rate: ::std::os::raw::c_uint,
+    pub clock_type: ::std::os::raw::c_uint,
+    pub loopback: ::std::os::raw::c_ushort,
+    pub slot_map: ::std::os::raw::c_uint,
+}
+
+impl Clone for te1_settings {
+    fn clone(&self) -> Self {
+        *self
+    }
+}

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -1,0 +1,147 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::borrow::{Borrow, BorrowMut};
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
+
+use vm_device::bus::MmioAddress;
+use vm_device::device_manager::MmioManager;
+use vm_device::{DeviceMmio, MutDeviceMmio};
+use vm_memory::GuestAddressSpace;
+use vm_virtio::device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
+use vm_virtio::Queue;
+
+use crate::virtio::features::{VIRTIO_F_IN_ORDER, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1};
+use crate::virtio::net::{Error, NetArgs, Result, NET_DEVICE_ID};
+use crate::virtio::{CommonConfig, Env, SingleFdSignalQueue, QUEUE_MAX_SIZE};
+
+use super::bindings;
+use super::features::*;
+use super::queue_handler::QueueHandler;
+use super::simple_handler::SimpleHandler;
+use super::tap::Tap;
+
+pub struct Net<M: GuestAddressSpace> {
+    cfg: CommonConfig<M>,
+    tap_name: String,
+}
+
+impl<M> Net<M>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+{
+    pub fn new<B>(env: &mut Env<M, B>, args: &NetArgs) -> Result<Arc<Mutex<Self>>>
+    where
+        // We're using this (more convoluted) bound so we can pass both references and smart
+        // pointers such as mutex guards here.
+        B: DerefMut,
+        B::Target: MmioManager<D = Arc<dyn DeviceMmio + Send + Sync>>,
+    {
+        let device_features = (1 << VIRTIO_F_VERSION_1)
+            | (1 << VIRTIO_F_RING_EVENT_IDX)
+            | (1 << VIRTIO_F_IN_ORDER)
+            | (1 << VIRTIO_NET_F_CSUM)
+            | (1 << VIRTIO_NET_F_GUEST_CSUM)
+            | (1 << VIRTIO_NET_F_GUEST_TSO4)
+            | (1 << VIRTIO_NET_F_GUEST_UFO)
+            | (1 << VIRTIO_NET_F_HOST_TSO4)
+            | (1 << VIRTIO_NET_F_HOST_UFO);
+
+        // An rx/tx queue pair.
+        let queues = vec![Queue::new(env.mem.clone(), QUEUE_MAX_SIZE); 2];
+        // TODO: We'll need a minimal config space to support setting an explicit MAC addr
+        // on the guest interface at least. We use an empty one for now.
+        let config_space = Vec::new();
+        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
+
+        let common_cfg = CommonConfig::new(virtio_cfg, env).map_err(Error::Generic)?;
+
+        let net = Arc::new(Mutex::new(Net {
+            cfg: common_cfg,
+            tap_name: args.tap_name.clone(),
+        }));
+
+        env.register_mmio_device(net.clone())
+            .map_err(Error::Generic)?;
+
+        Ok(net)
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceType for Net<M> {
+    fn device_type(&self) -> u32 {
+        NET_DEVICE_ID
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> Borrow<VirtioConfig<M>> for Net<M> {
+    fn borrow(&self) -> &VirtioConfig<M> {
+        &self.cfg.virtio
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> BorrowMut<VirtioConfig<M>> for Net<M> {
+    fn borrow_mut(&mut self) -> &mut VirtioConfig<M> {
+        &mut self.cfg.virtio
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Net<M> {
+    type E = Error;
+
+    fn activate(&mut self) -> Result<()> {
+        let rxq = self.cfg.virtio.queues[0].clone();
+        let txq = self.cfg.virtio.queues[1].clone();
+
+        let tap = Tap::open_named(self.tap_name.as_str()).map_err(Error::Tap)?;
+
+        // Set offload flags to match the relevant virtio features of the device (for now,
+        // statically set in the constructor.
+        tap.set_offload(
+            bindings::TUN_F_CSUM
+                | bindings::TUN_F_UFO
+                | bindings::TUN_F_TSO4
+                | bindings::TUN_F_TSO6,
+        )
+        .map_err(Error::Tap)?;
+
+        // The layout of the header is specified in the standard and is 12 bytes in size. We
+        // should define this somewhere.
+        tap.set_vnet_hdr_size(12).map_err(Error::Tap)?;
+
+        let driver_notify = SingleFdSignalQueue {
+            irqfd: self.cfg.irqfd.clone(),
+            interrupt_status: self.cfg.virtio.interrupt_status.clone(),
+        };
+
+        let inner = SimpleHandler::new(driver_notify, rxq, txq, tap);
+
+        let mut ioevents = self.cfg.prepare_activate().map_err(Error::Generic)?;
+
+        let handler = Arc::new(Mutex::new(QueueHandler {
+            inner,
+            rx_ioevent: ioevents.remove(0),
+            tx_ioevent: ioevents.remove(0),
+        }));
+
+        self.cfg.finalize_activate(handler).map_err(Error::Generic)
+    }
+
+    fn reset(&mut self) -> std::result::Result<(), Error> {
+        // Not implemented for now.
+        Ok(())
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioMmioDevice<M> for Net<M> {}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static> MutDeviceMmio for Net<M> {
+    fn mmio_read(&mut self, _base: MmioAddress, offset: u64, data: &mut [u8]) {
+        self.read(offset, data);
+    }
+
+    fn mmio_write(&mut self, _base: MmioAddress, offset: u64, data: &[u8]) {
+        self.write(offset, data);
+    }
+}

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -1,0 +1,43 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+mod bindings;
+mod device;
+mod queue_handler;
+mod simple_handler;
+pub mod tap;
+
+pub use device::Net;
+
+// TODO: Move relevant defines to vm-virtio crate.
+
+// Values taken from the virtio standard.
+pub mod features {
+    pub const VIRTIO_NET_F_CSUM: u64 = 0;
+    pub const VIRTIO_NET_F_GUEST_CSUM: u64 = 1;
+    pub const VIRTIO_NET_F_GUEST_TSO4: u64 = 7;
+    pub const VIRTIO_NET_F_GUEST_UFO: u64 = 10;
+    pub const VIRTIO_NET_F_HOST_TSO4: u64 = 11;
+    pub const VIRTIO_NET_F_HOST_UFO: u64 = 14;
+}
+
+// Net device ID as defined by the standard.
+pub const NET_DEVICE_ID: u32 = 1;
+
+// Prob have to find better names here, but these basically represent the order of the queues.
+// If the net device has a single RX/TX pair, then the former has index 0 and the latter 1. When
+// the device has multiqueue support, then RX queues have indices 2k, and TX queues 2k+1.
+const RXQ_INDEX: u16 = 0;
+const TXQ_INDEX: u16 = 1;
+
+#[derive(Debug)]
+pub enum Error {
+    Generic(crate::virtio::Error),
+    Tap(tap::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub struct NetArgs {
+    pub tap_name: String,
+}

--- a/src/devices/src/virtio/net/queue_handler.rs
+++ b/src/devices/src/virtio/net/queue_handler.rs
@@ -1,0 +1,95 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use event_manager::{EventOps, Events, MutEventSubscriber};
+use log::error;
+use vm_memory::GuestAddressSpace;
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::EventFd;
+
+use crate::virtio::SingleFdSignalQueue;
+
+use super::simple_handler::SimpleHandler;
+
+const TAPFD_DATA: u32 = 0;
+const RX_IOEVENT_DATA: u32 = 1;
+const TX_IOEVENT_DATA: u32 = 2;
+
+pub struct QueueHandler<M: GuestAddressSpace> {
+    pub inner: SimpleHandler<M, SingleFdSignalQueue>,
+    pub rx_ioevent: EventFd,
+    pub tx_ioevent: EventFd,
+}
+
+impl<M: GuestAddressSpace> QueueHandler<M> {
+    // Helper method that receives an error message to be logged and the `ops` handle
+    // which is used to unregister all events.
+    fn handle_error<S: AsRef<str>>(&self, s: S, ops: &mut EventOps) {
+        error!("{}", s.as_ref());
+        ops.remove(Events::empty(&self.rx_ioevent))
+            .expect("Failed to remove rx ioevent");
+        ops.remove(Events::empty(&self.tx_ioevent))
+            .expect("Failed to remove rx ioevent");
+        ops.remove(Events::empty(&self.inner.tap))
+            .expect("Failed to remove tap event");
+    }
+}
+
+impl<M: GuestAddressSpace> MutEventSubscriber for QueueHandler<M> {
+    fn process(&mut self, events: Events, ops: &mut EventOps) {
+        // TODO: We can also consider panicking on the errors that cannot be generated
+        // or influenced.
+
+        if events.event_set() != EventSet::IN {
+            self.handle_error("Unexpected event_set", ops);
+            return;
+        }
+
+        match events.data() {
+            TAPFD_DATA => {
+                if let Err(e) = self.inner.process_tap() {
+                    self.handle_error(format!("Process tap error {:?}", e), ops);
+                }
+            }
+            RX_IOEVENT_DATA => {
+                if self.rx_ioevent.read().is_err() {
+                    self.handle_error("Rx ioevent read", ops);
+                } else if let Err(e) = self.inner.process_rxq() {
+                    self.handle_error(format!("Process rx error {:?}", e), ops);
+                }
+            }
+            TX_IOEVENT_DATA => {
+                if self.tx_ioevent.read().is_err() {
+                    self.handle_error("Tx ioevent read", ops);
+                }
+                if let Err(e) = self.inner.process_txq() {
+                    self.handle_error(format!("Process tx error {:?}", e), ops);
+                }
+            }
+            _ => self.handle_error("Unexpected data", ops),
+        }
+    }
+
+    fn init(&mut self, ops: &mut EventOps) {
+        ops.add(Events::with_data(
+            &self.inner.tap,
+            TAPFD_DATA,
+            EventSet::IN | EventSet::EDGE_TRIGGERED,
+        ))
+        .expect("Unable to add tapfd");
+
+        ops.add(Events::with_data(
+            &self.rx_ioevent,
+            RX_IOEVENT_DATA,
+            EventSet::IN,
+        ))
+        .expect("Unable to add rxfd");
+
+        ops.add(Events::with_data(
+            &self.tx_ioevent,
+            TX_IOEVENT_DATA,
+            EventSet::IN,
+        ))
+        .expect("Unable to add txfd");
+    }
+}

--- a/src/devices/src/virtio/net/simple_handler.rs
+++ b/src/devices/src/virtio/net/simple_handler.rs
@@ -1,0 +1,188 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::cmp;
+use std::io::{self, Read, Write};
+use std::result;
+
+use log::warn;
+use vm_memory::{Bytes, GuestAddressSpace};
+use vm_virtio::{DescriptorChain, Queue};
+
+use crate::virtio::net::tap::Tap;
+use crate::virtio::net::{RXQ_INDEX, TXQ_INDEX};
+use crate::virtio::SignalUsedQueue;
+
+// According to the standard: "If the VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6 or
+// VIRTIO_NET_F_GUEST_UFO features are used, the maximum incoming packet will be to 65550
+// bytes long (the maximum size of a TCP or UDP packet, plus the 14 byte ethernet header),
+// otherwise 1514 bytes. The 12-byte struct virtio_net_hdr is prepended to this, making for
+// 65562 or 1526 bytes." For transmission, the standard states "The header and packet are added
+// as one output descriptor to the transmitq, and the device is notified of the new entry".
+// We assume the TX frame will not exceed this size either.
+const MAX_BUFFER_SIZE: usize = 65562;
+
+#[derive(Debug)]
+pub enum Error {
+    GuestMemory(vm_memory::GuestMemoryError),
+    Queue(vm_virtio::Error),
+    Tap(io::Error),
+}
+
+impl From<vm_virtio::Error> for Error {
+    fn from(e: vm_virtio::Error) -> Self {
+        Error::Queue(e)
+    }
+}
+
+// A simple handler implementation for a RX/TX queue pair, which does not make assumptions about
+// the way queue notification is implemented. The backend is not yet generic (we always assume a
+// `Tap` object), but we're looking at improving that going forward.
+// TODO: Find a better name.
+pub struct SimpleHandler<M: GuestAddressSpace, S: SignalUsedQueue> {
+    pub driver_notify: S,
+    pub rxq: Queue<M>,
+    pub rxbuf_current: usize,
+    pub rxbuf: [u8; MAX_BUFFER_SIZE],
+    pub txq: Queue<M>,
+    pub txbuf: [u8; MAX_BUFFER_SIZE],
+    pub tap: Tap,
+}
+
+impl<M: GuestAddressSpace, S: SignalUsedQueue> SimpleHandler<M, S> {
+    pub fn new(driver_notify: S, rxq: Queue<M>, txq: Queue<M>, tap: Tap) -> Self {
+        SimpleHandler {
+            driver_notify,
+            rxq,
+            rxbuf_current: 0,
+            rxbuf: [0u8; MAX_BUFFER_SIZE],
+            txq,
+            txbuf: [0u8; MAX_BUFFER_SIZE],
+            tap,
+        }
+    }
+
+    // Have to see how to approach error handling for the `Queue` implementation in particular,
+    // because many situations are not really recoverable. We should consider reporting them based
+    // on the  metrics/events solution when they appear, and not propagate them further unless
+    // it's really useful/necessary.
+    fn write_frame_to_guest(&mut self) -> result::Result<bool, Error> {
+        let num_bytes = self.rxbuf_current;
+
+        let mut chain = match self.rxq.iter()?.next() {
+            Some(c) => c,
+            _ => return Ok(false),
+        };
+
+        let mut count = 0;
+        let buf = &mut self.rxbuf[..num_bytes];
+
+        while let Some(desc) = chain.next() {
+            let left = buf.len() - count;
+
+            if left == 0 {
+                break;
+            }
+
+            let len = cmp::min(left, desc.len() as usize);
+            chain
+                .memory()
+                .write_slice(&buf[count..count + len], desc.addr())
+                .map_err(Error::GuestMemory)?;
+
+            count += len;
+        }
+
+        if count != buf.len() {
+            // The frame was too large for the chain.
+            warn!("rx frame too large");
+        }
+
+        self.rxq.add_used(chain.head_index(), count as u32)?;
+
+        self.rxbuf_current = 0;
+
+        Ok(true)
+    }
+
+    pub fn process_tap(&mut self) -> result::Result<(), Error> {
+        loop {
+            if self.rxbuf_current == 0 {
+                match self.tap.read(&mut self.rxbuf) {
+                    Ok(n) => self.rxbuf_current = n,
+                    Err(_) => {
+                        // TODO: Do something (logs, metrics, etc.) in response to an error when
+                        // reading from tap. EAGAIN means there's nothing available to read anymore
+                        // (because we open the TAP as non-blocking).
+                        break;
+                    }
+                }
+            }
+
+            if !self.write_frame_to_guest()? {
+                if !self.rxq.enable_notification()? {
+                    break;
+                }
+            }
+        }
+
+        if self.rxq.needs_notification()? {
+            self.driver_notify.signal_used_queue(RXQ_INDEX);
+        }
+
+        Ok(())
+    }
+
+    fn send_frame_from_chain(
+        &mut self,
+        chain: &mut DescriptorChain<M>,
+    ) -> result::Result<u32, Error> {
+        let mut count = 0;
+
+        while let Some(desc) = chain.next() {
+            let left = self.txbuf.len() - count;
+            let len = desc.len() as usize;
+
+            if len > left {
+                warn!("tx frame too large");
+                break;
+            }
+
+            chain
+                .memory()
+                .read_slice(&mut self.txbuf[count..count + len], desc.addr())
+                .map_err(Error::GuestMemory)?;
+
+            count += len;
+        }
+
+        self.tap.write(&self.txbuf[..count]).map_err(Error::Tap)?;
+
+        Ok(count as u32)
+    }
+
+    pub fn process_txq(&mut self) -> result::Result<(), Error> {
+        loop {
+            self.txq.disable_notification()?;
+
+            while let Some(mut chain) = self.txq.iter()?.next() {
+                let len = self.send_frame_from_chain(&mut chain)?;
+
+                self.txq.add_used(chain.head_index(), len)?;
+
+                if self.txq.needs_notification()? {
+                    self.driver_notify.signal_used_queue(TXQ_INDEX);
+                }
+            }
+
+            if !self.txq.enable_notification()? {
+                return Ok(());
+            }
+        }
+    }
+
+    pub fn process_rxq(&mut self) -> result::Result<(), Error> {
+        self.rxq.disable_notification()?;
+        self.process_tap()
+    }
+}

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -1,0 +1,456 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Portions Copyright 2017 The Chromium OS Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the THIRD-PARTY file.
+
+// We should add a tap abstraction to rust-vmm as well. Using this one, which is copied from
+// Firecracker until then.
+
+use std::fs::File;
+use std::io::{Error as IoError, Read, Result as IoResult, Write};
+use std::os::raw::{c_char, c_int, c_uint, c_ulong};
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+
+use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
+use vmm_sys_util::{ioctl_expr, ioctl_ioc_nr, ioctl_iow_nr};
+
+use super::bindings::ifreq;
+
+// As defined in the Linux UAPI:
+// https://elixir.bootlin.com/linux/v4.17/source/include/uapi/linux/if.h#L33
+const IFACE_NAME_MAX_LEN: usize = 16;
+
+// Taken from firecracker net_gen/if_tun.rs ... we should see what to do about the net related
+// bindings overall for rust-vmm.
+const IFF_TAP: ::std::os::raw::c_uint = 2;
+const IFF_NO_PI: ::std::os::raw::c_uint = 4096;
+const IFF_VNET_HDR: ::std::os::raw::c_uint = 16384;
+
+/// List of errors the tap implementation can throw.
+#[derive(Debug)]
+pub enum Error {
+    /// Unable to create tap interface.
+    CreateTap(IoError),
+    /// Invalid interface name.
+    InvalidIfname,
+    /// ioctl failed.
+    IoctlError(IoError),
+    /// Couldn't open /dev/net/tun.
+    OpenTun(IoError),
+}
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+const TUNTAP: ::std::os::raw::c_uint = 84;
+ioctl_iow_nr!(TUNSETIFF, TUNTAP, 202, ::std::os::raw::c_int);
+ioctl_iow_nr!(TUNSETOFFLOAD, TUNTAP, 208, ::std::os::raw::c_uint);
+ioctl_iow_nr!(TUNSETVNETHDRSZ, TUNTAP, 216, ::std::os::raw::c_int);
+
+/// Handle for a network tap interface.
+///
+/// For now, this simply wraps the file descriptor for the tap device so methods
+/// can run ioctls on the interface. The tap interface fd will be closed when
+/// Tap goes out of scope, and the kernel will clean up the interface automatically.
+#[derive(Debug)]
+pub struct Tap {
+    tap_file: File,
+    pub(crate) if_name: [u8; IFACE_NAME_MAX_LEN],
+}
+
+// Returns a byte vector representing the contents of a null terminated C string which
+// contains if_name.
+fn build_terminated_if_name(if_name: &str) -> Result<[u8; IFACE_NAME_MAX_LEN]> {
+    // Convert the string slice to bytes, and shadow the variable,
+    // since we no longer need the &str version.
+    let if_name = if_name.as_bytes();
+
+    if if_name.len() >= IFACE_NAME_MAX_LEN {
+        return Err(Error::InvalidIfname);
+    }
+
+    let mut terminated_if_name = [b'\0'; IFACE_NAME_MAX_LEN];
+    terminated_if_name[..if_name.len()].copy_from_slice(if_name);
+
+    Ok(terminated_if_name)
+}
+
+pub struct IfReqBuilder(ifreq);
+
+impl IfReqBuilder {
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+
+    pub fn if_name(mut self, if_name: &[u8; IFACE_NAME_MAX_LEN]) -> Self {
+        // Since we don't call as_mut on the same union field more than once, this block is safe.
+        let ifrn_name = unsafe { self.0.ifr_ifrn.ifrn_name.as_mut() };
+        ifrn_name.copy_from_slice(if_name.as_ref());
+
+        self
+    }
+
+    pub(crate) fn flags(mut self, flags: i16) -> Self {
+        // Since we don't call as_mut on the same union field more than once, this block is safe.
+        let ifru_flags = unsafe { self.0.ifr_ifru.ifru_flags.as_mut() };
+        *ifru_flags = flags;
+
+        self
+    }
+
+    pub(crate) fn execute<F: AsRawFd>(mut self, socket: &F, ioctl: u64) -> Result<ifreq> {
+        // ioctl is safe. Called with a valid socket fd, and we check the return.
+        let ret = unsafe { ioctl_with_mut_ref(socket, ioctl, &mut self.0) };
+        if ret < 0 {
+            return Err(Error::IoctlError(IoError::last_os_error()));
+        }
+
+        Ok(self.0)
+    }
+}
+
+impl Tap {
+    /// Create a TUN/TAP device given the interface name.
+    /// # Arguments
+    ///
+    /// * `if_name` - the name of the interface.
+    pub fn open_named(if_name: &str) -> Result<Tap> {
+        let terminated_if_name = build_terminated_if_name(if_name)?;
+
+        let fd = unsafe {
+            // Open calls are safe because we give a constant null-terminated
+            // string and verify the result.
+            libc::open(
+                b"/dev/net/tun\0".as_ptr() as *const c_char,
+                libc::O_RDWR | libc::O_NONBLOCK | libc::O_CLOEXEC,
+            )
+        };
+        if fd < 0 {
+            return Err(Error::OpenTun(IoError::last_os_error()));
+        }
+        // We just checked that the fd is valid.
+        let tuntap = unsafe { File::from_raw_fd(fd) };
+
+        let ifreq = IfReqBuilder::new()
+            .if_name(&terminated_if_name)
+            .flags((IFF_TAP | IFF_NO_PI | IFF_VNET_HDR) as i16)
+            .execute(&tuntap, TUNSETIFF())?;
+
+        // Safe since only the name is accessed, and it's cloned out.
+        Ok(Tap {
+            tap_file: tuntap,
+            if_name: unsafe { *ifreq.ifr_ifrn.ifrn_name.as_ref() },
+        })
+    }
+
+    pub fn if_name_as_str(&self) -> &str {
+        let len = self
+            .if_name
+            .iter()
+            .position(|x| *x == 0)
+            .unwrap_or(IFACE_NAME_MAX_LEN);
+        std::str::from_utf8(&self.if_name[..len]).unwrap_or("")
+    }
+
+    /// Set the offload flags for the tap interface.
+    pub fn set_offload(&self, flags: c_uint) -> Result<()> {
+        // ioctl is safe. Called with a valid tap fd, and we check the return.
+        let ret = unsafe { ioctl_with_val(&self.tap_file, TUNSETOFFLOAD(), c_ulong::from(flags)) };
+        if ret < 0 {
+            return Err(Error::IoctlError(IoError::last_os_error()));
+        }
+
+        Ok(())
+    }
+
+    /// Set the size of the vnet hdr.
+    pub fn set_vnet_hdr_size(&self, size: c_int) -> Result<()> {
+        // ioctl is safe. Called with a valid tap fd, and we check the return.
+        let ret = unsafe { ioctl_with_ref(&self.tap_file, TUNSETVNETHDRSZ(), &size) };
+        if ret < 0 {
+            return Err(Error::IoctlError(IoError::last_os_error()));
+        }
+
+        Ok(())
+    }
+}
+
+impl Read for Tap {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        self.tap_file.read(buf)
+    }
+}
+
+impl Write for Tap {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        self.tap_file.write(&buf)
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        Ok(())
+    }
+}
+
+impl AsRawFd for Tap {
+    fn as_raw_fd(&self) -> RawFd {
+        self.tap_file.as_raw_fd()
+    }
+}
+
+// The tests below are brought over from Firecracker, and generally require elevated
+// privileges to run.
+
+#[cfg(test)]
+pub mod tests {
+    use std::mem;
+    use std::os::unix::ffi::OsStrExt;
+    use std::process::Command;
+
+    use super::*;
+
+    // The size of the virtio net header
+    const VNET_HDR_SIZE: usize = 10;
+
+    const PAYLOAD_SIZE: usize = 512;
+    const PACKET_SIZE: usize = 1024;
+
+    // The following selectively taken from Firecracker net_gen, utils, and net::test_utils.
+
+    pub type net_device_flags = ::std::os::raw::c_uint;
+    pub const net_device_flags_IFF_UP: net_device_flags = 1;
+    pub const net_device_flags_IFF_RUNNING: net_device_flags = 64;
+    pub const net_device_flags_IFF_NOARP: net_device_flags = 128;
+
+    pub const ETH_HLEN: ::std::os::raw::c_uint = 14;
+    pub const SIOCGIFINDEX: ::std::os::raw::c_uint = 35123;
+    pub const SIOCSIFFLAGS: ::std::os::raw::c_uint = 35092;
+
+    pub struct TapTrafficSimulator {
+        socket: File,
+        send_addr: libc::sockaddr_ll,
+    }
+
+    impl TapTrafficSimulator {
+        pub fn new(tap_index: i32) -> Self {
+            // Create sockaddr_ll struct.
+            let send_addr_ptr = &unsafe { mem::zeroed() } as *const libc::sockaddr_storage;
+            unsafe {
+                let sock_addr: *mut libc::sockaddr_ll = send_addr_ptr as *mut libc::sockaddr_ll;
+                (*sock_addr).sll_family = libc::AF_PACKET as libc::sa_family_t;
+                (*sock_addr).sll_protocol = (libc::ETH_P_ALL as u16).to_be();
+                (*sock_addr).sll_halen = libc::ETH_ALEN as u8;
+                (*sock_addr).sll_ifindex = tap_index;
+            }
+
+            // Bind socket to tap interface.
+            let socket = create_socket();
+            let ret = unsafe {
+                libc::bind(
+                    socket.as_raw_fd(),
+                    send_addr_ptr as *const _,
+                    mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+                )
+            };
+            if ret == -1 {
+                panic!("Can't create TapChannel");
+            }
+
+            // Enable nonblocking
+            let ret = unsafe { libc::fcntl(socket.as_raw_fd(), libc::F_SETFL, libc::O_NONBLOCK) };
+            if ret == -1 {
+                panic!("Couldn't make TapChannel non-blocking");
+            }
+
+            Self {
+                socket,
+                send_addr: unsafe { *(send_addr_ptr as *const _) },
+            }
+        }
+
+        pub fn push_tx_packet(&self, buf: &[u8]) {
+            let res = unsafe {
+                libc::sendto(
+                    self.socket.as_raw_fd(),
+                    buf.as_ptr() as *const _,
+                    buf.len(),
+                    0,
+                    (&self.send_addr as *const libc::sockaddr_ll) as *const _,
+                    mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+                )
+            };
+            if res == -1 {
+                panic!("Can't inject tx_packet");
+            }
+        }
+
+        pub fn pop_rx_packet(&self, buf: &mut [u8]) -> bool {
+            let ret = unsafe {
+                libc::recvfrom(
+                    self.socket.as_raw_fd(),
+                    buf.as_ptr() as *mut _,
+                    buf.len(),
+                    0,
+                    (&mut mem::zeroed() as *mut libc::sockaddr_storage) as *mut _,
+                    &mut (mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t),
+                )
+            };
+            if ret == -1 {
+                return false;
+            }
+            true
+        }
+    }
+
+    // In Firecracker, this gets a pseudo random OsString of length `len` with characters
+    // in the range [a-zA-Z0-9]. Right here it always outputs the same string until we figure
+    // how to approach testing here overall, and whether the logic that makes use of this is
+    // something we're interested in having as well.
+    pub fn rand_alphanumerics(len: usize) -> std::ffi::OsString {
+        let mut s = std::ffi::OsString::new();
+        for _ in 0..len {
+            s.push("a");
+        }
+        s
+    }
+
+    pub fn create_socket() -> File {
+        // This is safe since we check the return value.
+        let socket = unsafe {
+            libc::socket(
+                libc::AF_PACKET,
+                libc::SOCK_RAW,
+                libc::ETH_P_ALL.to_be() as i32,
+            )
+        };
+        if socket < 0 {
+            panic!("Unable to create tap socket");
+        }
+
+        // This is safe; nothing else will use or hold onto the raw socket fd.
+        unsafe { File::from_raw_fd(socket) }
+    }
+
+    pub fn if_index(tap: &Tap) -> i32 {
+        let sock = create_socket();
+        let ifreq = IfReqBuilder::new()
+            .if_name(&tap.if_name)
+            .execute(&sock, c_ulong::from(SIOCGIFINDEX))
+            .unwrap();
+
+        unsafe { *ifreq.ifr_ifru.ifru_ivalue.as_ref() }
+    }
+
+    /// Enable the tap interface.
+    pub fn enable(tap: &Tap) {
+        // Disable IPv6 router advertisment requests
+        Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "echo 0 > /proc/sys/net/ipv6/conf/{}/accept_ra",
+                tap.if_name_as_str()
+            ))
+            .output()
+            .unwrap();
+
+        let sock = create_socket();
+        IfReqBuilder::new()
+            .if_name(&tap.if_name)
+            .flags(
+                (net_device_flags_IFF_UP
+                    | net_device_flags_IFF_RUNNING
+                    | net_device_flags_IFF_NOARP) as i16,
+            )
+            .execute(&sock, c_ulong::from(SIOCSIFFLAGS))
+            .unwrap();
+    }
+
+    #[test]
+    fn test_tap_name() {
+        // Sanity check that the assumed max iface name length is correct.
+        assert_eq!(
+            IFACE_NAME_MAX_LEN,
+            super::super::bindings::ifreq__bindgen_ty_1::default()
+                .bindgen_union_field
+                .len()
+        );
+
+        // 16 characters - too long.
+        let name = "a123456789abcdef";
+        match Tap::open_named(name) {
+            Err(Error::InvalidIfname) => (),
+            _ => panic!("Expected Error::InvalidIfname"),
+        };
+
+        // 15 characters - OK.
+        let name = "a123456789abcde";
+        let tap = Tap::open_named(name).unwrap();
+        assert_eq!(&format!("{}\0", name).as_bytes(), &tap.if_name);
+        assert_eq!(name, tap.if_name_as_str());
+    }
+
+    #[test]
+    fn test_tap_exclusive_open() {
+        let _tap1 = Tap::open_named("exclusivetap").unwrap();
+        // Opening same tap device a second time should not be permitted.
+        Tap::open_named("exclusivetap").unwrap_err();
+    }
+
+    #[test]
+    fn test_set_options() {
+        // This line will fail to provide an initialized FD if the test is not run as root.
+        let tap = Tap::open_named("").unwrap();
+        tap.set_vnet_hdr_size(16).unwrap();
+        tap.set_offload(0).unwrap();
+
+        let faulty_tap = Tap {
+            tap_file: unsafe { File::from_raw_fd(-1) },
+            if_name: [0x01; 16],
+        };
+        assert!(faulty_tap.set_vnet_hdr_size(16).is_err());
+        assert!(faulty_tap.set_offload(0).is_err());
+    }
+
+    #[test]
+    fn test_raw_fd() {
+        let tap = Tap::open_named("").unwrap();
+        assert_eq!(tap.as_raw_fd(), tap.tap_file.as_raw_fd());
+    }
+
+    #[test]
+    fn test_read() {
+        let mut tap = Tap::open_named("").unwrap();
+        enable(&tap);
+        let tap_traffic_simulator = TapTrafficSimulator::new(if_index(&tap));
+
+        let packet = rand_alphanumerics(PAYLOAD_SIZE);
+        tap_traffic_simulator.push_tx_packet(packet.as_bytes());
+
+        let mut buf = [0u8; PACKET_SIZE];
+        assert!(tap.read(&mut buf).is_ok());
+        assert_eq!(
+            &buf[VNET_HDR_SIZE..packet.len() + VNET_HDR_SIZE],
+            packet.as_bytes()
+        );
+    }
+
+    #[test]
+    fn test_write() {
+        let mut tap = Tap::open_named("").unwrap();
+        enable(&tap);
+        let tap_traffic_simulator = TapTrafficSimulator::new(if_index(&tap));
+
+        let mut packet = [0u8; PACKET_SIZE];
+        let payload = rand_alphanumerics(PAYLOAD_SIZE);
+        packet[ETH_HLEN as usize..payload.len() + ETH_HLEN as usize]
+            .copy_from_slice(payload.as_bytes());
+        assert!(tap.write(&packet).is_ok());
+
+        let mut read_buf = [0u8; PACKET_SIZE];
+        assert!(tap_traffic_simulator.pop_rx_packet(&mut read_buf));
+        assert_eq!(
+            &read_buf[..PACKET_SIZE - VNET_HDR_SIZE],
+            &packet[VNET_HDR_SIZE..]
+        );
+    }
+}

--- a/src/devices/src/virtio/vsock/byte_order.rs
+++ b/src/devices/src/virtio/vsock/byte_order.rs
@@ -1,0 +1,109 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+macro_rules! generate_read_fn {
+    ($fn_name: ident, $data_type: ty, $byte_type: ty, $type_size: expr, $endian_type: ident) => {
+        pub fn $fn_name(input: &[$byte_type]) -> $data_type {
+            assert!($type_size == std::mem::size_of::<$data_type>());
+            let mut array = [0u8; $type_size];
+            for (byte, read) in array.iter_mut().zip(input.iter().cloned()) {
+                *byte = read as u8;
+            }
+            <$data_type>::$endian_type(array)
+        }
+    };
+}
+
+macro_rules! generate_write_fn {
+    ($fn_name: ident, $data_type: ty, $byte_type: ty, $endian_type: ident) => {
+        pub fn $fn_name(buf: &mut [$byte_type], n: $data_type) {
+            for (byte, read) in buf
+                .iter_mut()
+                .zip(<$data_type>::$endian_type(n).iter().cloned())
+            {
+                *byte = read as $byte_type;
+            }
+        }
+    };
+}
+
+generate_read_fn!(read_le_u16, u16, u8, 2, from_le_bytes);
+generate_read_fn!(read_le_u32, u32, u8, 4, from_le_bytes);
+generate_read_fn!(read_le_u64, u64, u8, 8, from_le_bytes);
+generate_read_fn!(read_le_i32, i32, i8, 4, from_le_bytes);
+
+generate_read_fn!(read_be_u16, u16, u8, 2, from_be_bytes);
+generate_read_fn!(read_be_u32, u32, u8, 4, from_be_bytes);
+
+generate_write_fn!(write_le_u16, u16, u8, to_le_bytes);
+generate_write_fn!(write_le_u32, u32, u8, to_le_bytes);
+generate_write_fn!(write_le_u64, u64, u8, to_le_bytes);
+generate_write_fn!(write_le_i32, i32, i8, to_le_bytes);
+
+generate_write_fn!(write_be_u16, u16, u8, to_be_bytes);
+generate_write_fn!(write_be_u32, u32, u8, to_be_bytes);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    macro_rules! byte_order_test_read_write {
+        ($test_name: ident, $write_fn_name: ident, $read_fn_name: ident, $is_be: expr, $data_type: ty) => {
+            #[test]
+            fn $test_name() {
+                #[allow(overflowing_literals)]
+                let test_cases = [
+                    (
+                        0x0123_4567_89AB_CDEF as u64,
+                        [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef],
+                    ),
+                    (
+                        0x0000_0000_0000_0000 as u64,
+                        [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+                    ),
+                    (
+                        0x1923_2345_ABF3_CCD4 as u64,
+                        [0x19, 0x23, 0x23, 0x45, 0xAB, 0xF3, 0xCC, 0xD4],
+                    ),
+                    (
+                        0x0FF0_0FF0_0FF0_0FF0 as u64,
+                        [0x0F, 0xF0, 0x0F, 0xF0, 0x0F, 0xF0, 0x0F, 0xF0],
+                    ),
+                    (
+                        0xFFFF_FFFF_FFFF_FFFF as u64,
+                        [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
+                    ),
+                    (
+                        0x89AB_12D4_C2D2_09BB as u64,
+                        [0x89, 0xAB, 0x12, 0xD4, 0xC2, 0xD2, 0x09, 0xBB],
+                    ),
+                ];
+
+                let type_size = std::mem::size_of::<$data_type>();
+                for (test_val, v_arr) in &test_cases {
+                    let v = *test_val as $data_type;
+                    let cmp_iter: Box<dyn Iterator<Item = _>> = if $is_be {
+                        Box::new(v_arr[(8 - type_size)..].iter())
+                    } else {
+                        Box::new(v_arr.iter().rev())
+                    };
+                    // test write
+                    let mut write_arr = vec![Default::default(); type_size];
+                    $write_fn_name(&mut write_arr, v);
+                    for (cmp, cur) in cmp_iter.zip(write_arr.iter()) {
+                        assert_eq!(*cmp, *cur as u8)
+                    }
+                    // test read
+                    let read_val = $read_fn_name(&write_arr);
+                    assert_eq!(v, read_val);
+                }
+            }
+        };
+    }
+
+    byte_order_test_read_write!(test_le_u16, write_le_u16, read_le_u16, false, u16);
+    byte_order_test_read_write!(test_le_u32, write_le_u32, read_le_u32, false, u32);
+    byte_order_test_read_write!(test_le_u64, write_le_u64, read_le_u64, false, u64);
+    byte_order_test_read_write!(test_le_i32, write_le_i32, read_le_i32, false, i32);
+    byte_order_test_read_write!(test_be_u16, write_be_u16, read_be_u16, true, u16);
+    byte_order_test_read_write!(test_be_u32, write_be_u32, read_be_u32, true, u32);
+}

--- a/src/devices/src/virtio/vsock/csm/connection.rs
+++ b/src/devices/src/virtio/vsock/csm/connection.rs
@@ -1,0 +1,677 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+/// The main job of `VsockConnection` is to forward data traffic, back and forth, between a
+/// guest-side AF_VSOCK socket and a host-side generic `Read + Write + AsRawFd` stream, while
+/// also managing its internal state.
+/// To that end, `VsockConnection` implements:
+/// - `VsockChannel` for:
+///   - moving data from the host stream to a guest-provided RX buffer, via `recv_pkt()`; and
+///   - moving data from a guest-provided TX buffer to the host stream, via `send_pkt()`; and
+///   - updating its internal state, by absorbing control packets (anything other than
+///     VSOCK_OP_RW).
+/// - `VsockEpollListener` for getting notified about the availability of data or free buffer
+///   space at the host stream.
+///
+/// Note: there is a certain asymmetry to the RX and TX data flows:
+///       - RX transfers do not need any data buffering, since data is read straight from the
+///         host stream and into the guest-provided RX buffer;
+///       - TX transfers may require some data to be buffered by `VsockConnection`, if the host
+///         peer can't keep up with reading the data that we're writing. This is because, once
+///         the guest driver provides some data in a virtio TX buffer, the vsock device must
+///         consume it.  If that data can't be forwarded straight to the host stream, we'll
+///         have to store it in a buffer (and flush it at a later time). Vsock flow control
+///         ensures that our TX buffer doesn't overflow.
+// The code in this file is best read with a fresh memory of the vsock protocol inner-workings.
+// To help with that, here is a
+//
+// Short primer on the vsock protocol
+// ----------------------------------
+//
+// 1. Establishing a connection
+//    A vsock connection is considered established after a two-way handshake:
+//    - the initiating peer sends a connection request packet (`hdr.op` == VSOCK_OP_REQUEST);
+//      then
+//    - the listening peer sends back a connection response packet (`hdr.op` ==
+//      VSOCK_OP_RESPONSE).
+//
+// 2. Terminating a connection
+//    When a peer wants to shut down an established connection, it sends a VSOCK_OP_SHUTDOWN
+//    packet. Two header flags are used with VSOCK_OP_SHUTDOWN, indicating the sender's
+//    intention:
+//    - VSOCK_FLAGS_SHUTDOWN_RCV: the sender will receive no more data for this connection; and
+//    - VSOCK_FLAGS_SHUTDOWN_SEND: the sender will send no more data for this connection.
+//    After a shutdown packet, the receiving peer will have some protocol-undefined time to
+//    flush its buffers, and then forcefully terminate the connection by sending back an RST
+//    packet. If the shutdown-initiating peer doesn't receive this RST packet during a timeout
+//    period, it will send one itself, thus terminating the connection.
+//    Note: a peer can send more than one VSOCK_OP_SHUTDOWN packets. However, read/write
+//          indications cannot be undone. E.g. once a "no-more-sending" promise was made, it
+//          cannot be taken back.  That is, `hdr.flags` will be ORed between subsequent
+//          VSOCK_OP_SHUTDOWN packets.
+//
+// 3. Flow control
+//    Before sending a data packet (VSOCK_OP_RW), the sender must make sure that the receiver
+//    has enough free buffer space to store that data. If this condition is not respected, the
+//    receiving peer's behaviour is undefined. In this implementation, we forcefully terminate
+//    the connection by sending back a VSOCK_OP_RST packet.
+//    Note: all buffer space information is computed and stored on a per-connection basis.
+//    Peers keep each other informed about the free buffer space they have by filling in two
+//    packet header members with each packet they send:
+//    - `hdr.buf_alloc`: the total buffer space the peer has allocated for receiving data; and
+//    - `hdr.fwd_cnt`: the total number of bytes the peer has successfully flushed out of its
+//       buffer.
+//    One can figure out how much space its peer has available in its buffer by inspecting the
+//    difference between how much it has sent to the peer and how much the peer has flushed out
+//    (i.e.  "forwarded", in the vsock spec terminology):
+//    `peer_free = peer_buf_alloc - (total_bytes_sent_to_peer - peer_fwd_cnt)`.
+//    Note: the above requires that peers constantly keep each other informed on their buffer
+//          space situation. However, since there are no receipt acknowledgement packets
+//          defined for the vsock protocol, packet flow can often be unidirectional (just one
+//          peer sending data to another), so the sender's information about the receiver's
+//          buffer space can get quickly outdated. The vsock protocol defines two solutions to
+//          this problem:
+//          1. The sender can explicitly ask for a buffer space (i.e. "credit") update from its
+//             peer, via a VSOCK_OP_CREDIT_REQUEST packet, to which it will get a
+//             VSOCK_OP_CREDIT_UPDATE response (or any response will do, really, since credit
+//             information must be included in any packet);
+//          2. The receiver can be proactive, and send VSOCK_OP_CREDIT_UPDATE packet, whenever
+//             it thinks its peer's information is out of date.
+//          Our implementation uses the proactive approach.
+use std::io::{ErrorKind, Read, Write};
+use std::num::Wrapping;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::time::{Duration, Instant};
+
+use log::{debug, error, info, warn};
+use vmm_sys_util::epoll::EventSet;
+
+use super::super::defs::uapi;
+use super::super::packet::VsockPacket;
+use super::super::{Result as VsockResult, VsockChannel, VsockEpollListener, VsockError};
+use super::defs;
+use super::txbuf::TxBuf;
+use super::{ConnState, Error, PendingRx, PendingRxSet, Result};
+
+/// A self-managing connection object, that handles communication between a guest-side AF_VSOCK
+/// socket and a host-side `Read + Write + AsRawFd` stream.
+pub struct VsockConnection<S: Read + Write + AsRawFd> {
+    /// The current connection state.
+    state: ConnState,
+    /// The local CID. Most of the time this will be the constant `2` (the vsock host CID).
+    local_cid: u64,
+    /// The peer (guest) CID.
+    peer_cid: u64,
+    /// The local (host) port.
+    local_port: u32,
+    /// The peer (guest) port.
+    peer_port: u32,
+    /// The (connected) host-side stream.
+    stream: S,
+    /// The TX buffer for this connection.
+    tx_buf: TxBuf,
+    /// Total number of bytes that have been successfully written to `self.stream`, either
+    /// directly, or flushed from `self.tx_buf`.
+    fwd_cnt: Wrapping<u32>,
+    /// The amount of buffer space that the peer (guest) has allocated for this connection.
+    peer_buf_alloc: u32,
+    /// The total number of bytes that the peer has forwarded away.
+    peer_fwd_cnt: Wrapping<u32>,
+    /// The total number of bytes sent to the peer (guest vsock driver)
+    rx_cnt: Wrapping<u32>,
+    /// Our `self.fwd_cnt`, as last sent to the peer. This is used to provide proactive credit
+    /// updates, and let the peer know it's OK to send more data.
+    last_fwd_cnt_to_peer: Wrapping<u32>,
+    /// The set of pending RX packet indications that `recv_pkt()` will use to fill in a
+    /// packet for the peer (guest).
+    pending_rx: PendingRxSet,
+    /// Instant when this connection should be scheduled for immediate termination, due to some
+    /// timeout condition having been fulfilled.
+    expiry: Option<Instant>,
+}
+
+impl<S> VsockChannel for VsockConnection<S>
+where
+    S: Read + Write + AsRawFd,
+{
+    /// Fill in a vsock packet, to be delivered to our peer (the guest driver).
+    ///
+    /// As per the `VsockChannel` trait, this should only be called when there is data to be
+    /// fetched from the channel (i.e. `has_pending_rx()` is true). Otherwise, it will error
+    /// out with `VsockError::NoData`.
+    /// Pending RX indications are set by other mutable actions performed on the channel. For
+    /// instance, `send_pkt()` could set an Rst indication, if called with a VSOCK_OP_SHUTDOWN
+    /// packet, or `notify()` could set a Rw indication (a data packet can be fetched from the
+    /// channel), if data was ready to be read from the host stream.
+    ///
+    /// Returns:
+    /// - `Ok(())`: the packet has been successfully filled in and is ready for delivery;
+    /// - `Err(VsockError::NoData)`: there was no data available with which to fill in the
+    ///    packet;
+    /// - `Err(VsockError::PktBufMissing)`: the packet would've been filled in with data, but
+    ///    it is missing the data buffer.
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> VsockResult<()> {
+        // Perform some generic initialization that is the same for any packet operation (e.g.
+        // source, destination, credit, etc).
+        self.init_pkt(pkt);
+
+        // METRICS.vsock.rx_packets_count.inc();
+
+        // If forceful termination is pending, there's no point in checking for anything else.
+        // It's dead, Jim.
+        if self.pending_rx.remove(PendingRx::Rst) {
+            pkt.set_op(uapi::VSOCK_OP_RST);
+            return Ok(());
+        }
+
+        // Next up: if we're due a connection confirmation, that's all we need to know to fill
+        // in this packet.
+        if self.pending_rx.remove(PendingRx::Response) {
+            self.state = ConnState::Established;
+            pkt.set_op(uapi::VSOCK_OP_RESPONSE);
+            return Ok(());
+        }
+
+        // Same thing goes for locally-initiated connections that need to yield a connection
+        // request.
+        if self.pending_rx.remove(PendingRx::Request) {
+            self.expiry =
+                Some(Instant::now() + Duration::from_millis(defs::CONN_REQUEST_TIMEOUT_MS));
+            pkt.set_op(uapi::VSOCK_OP_REQUEST);
+            return Ok(());
+        }
+
+        if self.pending_rx.remove(PendingRx::Rw) {
+            // We're due to produce a data packet, by reading the data from the host-side
+            // Unix socket.
+
+            match self.state {
+                // A data packet is only valid for established connections, and connections for
+                // which our peer has initiated a graceful shutdown, but can still receive data.
+                ConnState::Established | ConnState::PeerClosed(false, _) => (),
+                _ => {
+                    // Any other connection state is invalid at this point, and we need to kill it
+                    // with fire.
+                    pkt.set_op(uapi::VSOCK_OP_RST);
+                    return Ok(());
+                }
+            }
+
+            // Oh wait, before we start bringing in the big data, can our peer handle receiving so
+            // much bytey goodness?
+            if self.need_credit_update_from_peer() {
+                self.last_fwd_cnt_to_peer = self.fwd_cnt;
+                pkt.set_op(uapi::VSOCK_OP_CREDIT_REQUEST);
+                return Ok(());
+            }
+
+            let buf = pkt.buf_mut().ok_or(VsockError::PktBufMissing)?;
+
+            // The maximum amount of data we can read in is limited by both the RX buffer size and
+            // the peer available buffer space.
+            let max_len = std::cmp::min(buf.len(), self.peer_avail_credit());
+
+            // Read data from the stream straight to the RX buffer, for maximum throughput.
+            match self.stream.read(&mut buf[..max_len]) {
+                Ok(read_cnt) => {
+                    if read_cnt == 0 {
+                        // A 0-length read means the host stream was closed down. In that case,
+                        // we'll ask our peer to shut down the connection. We can neither send nor
+                        // receive any more data.
+                        self.state = ConnState::LocalClosed;
+                        self.expiry = Some(
+                            Instant::now() + Duration::from_millis(defs::CONN_SHUTDOWN_TIMEOUT_MS),
+                        );
+                        pkt.set_op(uapi::VSOCK_OP_SHUTDOWN)
+                            .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_RCV)
+                            .set_flag(uapi::VSOCK_FLAGS_SHUTDOWN_SEND);
+                    } else {
+                        // On a successful data read, we fill in the packet with the RW op, and
+                        // length of the read data.
+                        pkt.set_op(uapi::VSOCK_OP_RW).set_len(read_cnt as u32);
+
+                        // METRICS.vsock.rx_bytes_count.add(read_cnt);
+                    }
+                    self.rx_cnt += Wrapping(pkt.len());
+                    self.last_fwd_cnt_to_peer = self.fwd_cnt;
+                    return Ok(());
+                }
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    // This shouldn't actually happen (receiving EWOULDBLOCK after EPOLLIN), but
+                    // apparently it does, so we need to handle it greacefully.
+                    warn!(
+                        "vsock: unexpected EWOULDBLOCK while reading from backing stream: \
+                         lp={}, pp={}, err={:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                }
+                Err(err) => {
+                    // We are not expecting any other errors when reading from the underlying
+                    // stream. If any show up, we'll immediately kill this connection.
+
+                    // METRICS.vsock.rx_read_fails.inc();
+
+                    error!(
+                        "vsock: error reading from backing stream: lp={}, pp={}, err={:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                    pkt.set_op(uapi::VSOCK_OP_RST);
+                    self.last_fwd_cnt_to_peer = self.fwd_cnt;
+                    return Ok(());
+                }
+            };
+        }
+
+        // A credit update is basically a no-op, so we should only waste a perfectly fine RX
+        // buffer on it if we really have nothing else to say, hence we check for this RX
+        // indication last.
+        if self.pending_rx.remove(PendingRx::CreditUpdate) && !self.has_pending_rx() {
+            pkt.set_op(uapi::VSOCK_OP_CREDIT_UPDATE);
+            self.last_fwd_cnt_to_peer = self.fwd_cnt;
+            return Ok(());
+        }
+
+        // We've already checked for all conditions that would have produced a packet, so
+        // if we got to here, we don't know how to yield one.
+        Err(VsockError::NoData)
+    }
+
+    /// Deliver a guest-generated packet to this connection.
+    ///
+    /// This forwards the data in RW packets to the host stream, and absorbs control packets,
+    /// using them to manage the internal connection state.
+    ///
+    /// Returns:
+    /// always `Ok(())`: the packet has been consumed;
+    fn send_pkt(&mut self, pkt: &VsockPacket) -> VsockResult<()> {
+        // Update the peer credit information.
+        self.peer_buf_alloc = pkt.buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+
+        // METRICS.vsock.tx_packets_count.inc();
+
+        match self.state {
+            // Most frequent case: this is an established connection that needs to forward some
+            // data to the host stream. Also works for a connection that has begun shutting
+            // down, but the peer still has some data to send.
+            ConnState::Established | ConnState::PeerClosed(_, false)
+                if pkt.op() == uapi::VSOCK_OP_RW =>
+            {
+                if pkt.buf().is_none() {
+                    info!(
+                        "vsock: dropping empty data packet from guest (lp={}, pp={}",
+                        self.local_port, self.peer_port
+                    );
+                    return Ok(());
+                }
+
+                // Unwrapping here is safe, since we just checked `pkt.buf()` above.
+                let buf_slice = &pkt.buf().unwrap()[..(pkt.len() as usize)];
+                if let Err(err) = self.send_bytes(buf_slice) {
+                    // If we can't write to the host stream, that's an unrecoverable error, so
+                    // we'll terminate this connection.
+                    warn!(
+                        "vsock: error writing to local stream (lp={}, pp={}): {:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                    self.kill();
+                    return Ok(());
+                }
+
+                // We might've just consumed some data. If that's the case, we might need to
+                // update the peer on our buffer space situation, so that it can keep sending
+                // data packets our way.
+                if self.peer_needs_credit_update() {
+                    self.pending_rx.insert(PendingRx::CreditUpdate);
+                }
+            }
+
+            // Next up: receiving a response / confirmation for a host-initiated connection.
+            // We'll move to an Established state, and pass on the good news through the host
+            // stream.
+            ConnState::LocalInit if pkt.op() == uapi::VSOCK_OP_RESPONSE => {
+                self.expiry = None;
+                self.state = ConnState::Established;
+            }
+
+            // The peer wants to shut down an established connection.  If they have nothing
+            // more to send nor receive, and we don't have to wait to drain our TX buffer, we
+            // can schedule an RST packet (to terminate the connection on the next recv call).
+            // Otherwise, we'll arm the kill timer.
+            ConnState::Established if pkt.op() == uapi::VSOCK_OP_SHUTDOWN => {
+                let recv_off = pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_RCV != 0;
+                let send_off = pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_SEND != 0;
+                self.state = ConnState::PeerClosed(recv_off, send_off);
+                if recv_off && send_off {
+                    if self.tx_buf.is_empty() {
+                        self.pending_rx.insert(PendingRx::Rst);
+                    } else {
+                        self.expiry = Some(
+                            Instant::now() + Duration::from_millis(defs::CONN_SHUTDOWN_TIMEOUT_MS),
+                        );
+                    }
+                }
+            }
+
+            // The peer wants to update a shutdown request, with more receive/send indications.
+            // The same logic as above applies.
+            ConnState::PeerClosed(ref mut recv_off, ref mut send_off)
+                if pkt.op() == uapi::VSOCK_OP_SHUTDOWN =>
+            {
+                *recv_off = *recv_off || (pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_RCV != 0);
+                *send_off = *send_off || (pkt.flags() & uapi::VSOCK_FLAGS_SHUTDOWN_SEND != 0);
+                if *recv_off && *send_off && self.tx_buf.is_empty() {
+                    self.pending_rx.insert(PendingRx::Rst);
+                }
+            }
+
+            // A credit update from our peer is valid only in a state which allows data
+            // transfer towards the peer.
+            ConnState::Established | ConnState::PeerInit | ConnState::PeerClosed(false, _)
+                if pkt.op() == uapi::VSOCK_OP_CREDIT_UPDATE =>
+            {
+                // Nothing to do here; we've already updated peer credit.
+            }
+
+            // A credit request from our peer is valid only in a state which allows data
+            // transfer from the peer. We'll respond with a credit update packet.
+            ConnState::Established | ConnState::PeerInit | ConnState::PeerClosed(_, false)
+                if pkt.op() == uapi::VSOCK_OP_CREDIT_REQUEST =>
+            {
+                self.pending_rx.insert(PendingRx::CreditUpdate);
+            }
+
+            _ => {
+                debug!(
+                    "vsock: dropping invalid TX pkt for connection: state={:?}, pkt.hdr={:?}",
+                    self.state,
+                    pkt.hdr()
+                );
+            }
+        };
+
+        Ok(())
+    }
+
+    /// Check if the connection has any pending packet addressed to the peer.
+    fn has_pending_rx(&self) -> bool {
+        !self.pending_rx.is_empty()
+    }
+}
+
+impl<S> AsRawFd for VsockConnection<S>
+where
+    S: Read + Write + AsRawFd,
+{
+    /// Get the file descriptor that this connection wants polled.
+    ///
+    /// The connection is interested in being notified about EPOLLIN / EPOLLOUT events on the
+    /// host stream.
+    fn as_raw_fd(&self) -> RawFd {
+        self.stream.as_raw_fd()
+    }
+}
+
+impl<S> VsockEpollListener for VsockConnection<S>
+where
+    S: Read + Write + AsRawFd,
+{
+    /// Get the event set that this connection is interested in.
+    ///
+    /// A connection will want to be notified when:
+    /// - data is available to be read from the host stream, so that it can store an RW pending
+    ///   RX indication; and
+    /// - data can be written to the host stream, and the TX buffer needs to be flushed.
+    fn get_polled_evset(&self) -> EventSet {
+        let mut evset = EventSet::empty();
+        if !self.tx_buf.is_empty() {
+            // There's data waiting in the TX buffer, so we are interested in being notified
+            // when writing to the host stream wouldn't block.
+            evset.insert(EventSet::OUT);
+        }
+        // We're generally interested in being notified when data can be read from the host
+        // stream, unless we're in a state which doesn't allow moving data from host to guest.
+        match self.state {
+            ConnState::Killed | ConnState::LocalClosed | ConnState::PeerClosed(true, _) => (),
+            _ if self.need_credit_update_from_peer() => (),
+            _ => evset.insert(EventSet::IN),
+        }
+        evset
+    }
+
+    /// Notify the connection about an event (or set of events) that it was interested in.
+    fn notify(&mut self, evset: EventSet) {
+        if evset.contains(EventSet::IN) {
+            // Data can be read from the host stream. Setting a Rw pending indication, so that
+            // the muxer will know to call `recv_pkt()` later.
+            self.pending_rx.insert(PendingRx::Rw);
+        }
+
+        if evset.contains(EventSet::OUT) {
+            // Data can be written to the host stream. Time to flush out the TX buffer.
+            //
+            if self.tx_buf.is_empty() {
+                // METRICS.vsock.conn_event_fails.inc();
+
+                info!("vsock: connection received unexpected EPOLLOUT event");
+                return;
+            }
+            let flushed = self
+                .tx_buf
+                .flush_to(&mut self.stream)
+                .unwrap_or_else(|err| {
+                    // METRICS.vsock.tx_flush_fails.inc();
+
+                    warn!(
+                        "vsock: error flushing TX buf for (lp={}, pp={}): {:?}",
+                        self.local_port, self.peer_port, err
+                    );
+                    match err {
+                        Error::TxBufFlush(inner) if inner.kind() == ErrorKind::WouldBlock => {
+                            // This should never happen (EWOULDBLOCK after EPOLLOUT), but
+                            // it does, so let's absorb it.
+                        }
+                        _ => self.kill(),
+                    };
+                    0
+                });
+            self.fwd_cnt += Wrapping(flushed as u32);
+
+            // METRICS.vsock.tx_bytes_count.add(flushed as usize);
+
+            // If this connection was shutting down, but is waiting to drain the TX buffer
+            // before forceful termination, the wait might be over.
+            if self.state == ConnState::PeerClosed(true, true) && self.tx_buf.is_empty() {
+                self.pending_rx.insert(PendingRx::Rst);
+            } else if self.peer_needs_credit_update() {
+                // If we've freed up some more buffer space, we may need to let the peer know it
+                // can safely send more data our way.
+                self.pending_rx.insert(PendingRx::CreditUpdate);
+            }
+        }
+    }
+}
+
+impl<S> VsockConnection<S>
+where
+    S: Read + Write + AsRawFd,
+{
+    /// Create a new guest-initiated connection object.
+    pub fn new_peer_init(
+        stream: S,
+        local_cid: u64,
+        peer_cid: u64,
+        local_port: u32,
+        peer_port: u32,
+        peer_buf_alloc: u32,
+    ) -> Self {
+        Self {
+            local_cid,
+            peer_cid,
+            local_port,
+            peer_port,
+            stream,
+            state: ConnState::PeerInit,
+            tx_buf: TxBuf::new(),
+            fwd_cnt: Wrapping(0),
+            peer_buf_alloc,
+            peer_fwd_cnt: Wrapping(0),
+            rx_cnt: Wrapping(0),
+            last_fwd_cnt_to_peer: Wrapping(0),
+            pending_rx: PendingRxSet::from(PendingRx::Response),
+            expiry: None,
+        }
+    }
+
+    /// Create a new host-initiated connection object.
+    pub fn new_local_init(
+        stream: S,
+        local_cid: u64,
+        peer_cid: u64,
+        local_port: u32,
+        peer_port: u32,
+    ) -> Self {
+        Self {
+            local_cid,
+            peer_cid,
+            local_port,
+            peer_port,
+            stream,
+            state: ConnState::LocalInit,
+            tx_buf: TxBuf::new(),
+            fwd_cnt: Wrapping(0),
+            peer_buf_alloc: 0,
+            peer_fwd_cnt: Wrapping(0),
+            rx_cnt: Wrapping(0),
+            last_fwd_cnt_to_peer: Wrapping(0),
+            pending_rx: PendingRxSet::from(PendingRx::Request),
+            expiry: None,
+        }
+    }
+
+    /// Check if there is an expiry (kill) timer set for this connection, sometime in the
+    /// future.
+    pub fn will_expire(&self) -> bool {
+        match self.expiry {
+            None => false,
+            Some(t) => t > Instant::now(),
+        }
+    }
+
+    /// Check if this connection needs to be scheduled for forceful termination, due to its
+    /// kill timer having expired.
+    pub fn has_expired(&self) -> bool {
+        match self.expiry {
+            None => false,
+            Some(t) => t <= Instant::now(),
+        }
+    }
+
+    /// Get the kill timer value, if one is set.
+    pub fn expiry(&self) -> Option<Instant> {
+        self.expiry
+    }
+
+    /// Schedule the connection to be forcefully terminated ASAP (i.e. the next time the
+    /// connection is asked to yield a packet, via `recv_pkt()`).
+    pub fn kill(&mut self) {
+        self.state = ConnState::Killed;
+        self.pending_rx.insert(PendingRx::Rst);
+    }
+
+    /// Return the connections state.
+    pub fn state(&self) -> ConnState {
+        self.state
+    }
+
+    /// Send some raw, untracked, data straight to the underlying connected stream.
+    /// Returns: number of bytes written, or the error describing the write failure.
+    ///
+    /// Warning: this will bypass the connection state machine and write directly to the
+    /// underlying stream. No account of this write is kept, which includes bypassing
+    /// vsock flow control.
+    pub fn send_bytes_raw(&mut self, buf: &[u8]) -> Result<usize> {
+        self.stream.write(buf).map_err(Error::StreamWrite)
+    }
+
+    /// Send some raw data (a byte-slice) to the host stream.
+    ///
+    /// Raw data can either be sent straight to the host stream, or to our TX buffer, if the
+    /// former fails.
+    fn send_bytes(&mut self, buf: &[u8]) -> Result<()> {
+        // If there is data in the TX buffer, that means we're already registered for EPOLLOUT
+        // events on the underlying stream. Therefore, there's no point in attempting a write
+        // at this point. `self.notify()` will get called when EPOLLOUT arrives, and it will
+        // attempt to drain the TX buffer then.
+        if !self.tx_buf.is_empty() {
+            return self.tx_buf.push(buf);
+        }
+
+        // The TX buffer is empty, so we can try to write straight to the host stream.
+        let written = match self.stream.write(buf) {
+            Ok(cnt) => cnt,
+            Err(e) => {
+                // Absorb any would-block errors, since we can always try again later.
+                if e.kind() == ErrorKind::WouldBlock {
+                    0
+                } else {
+                    // We don't know how to handle any other write error, so we'll send it up
+                    // the call chain.
+
+                    // METRICS.vsock.tx_write_fails.inc();
+
+                    return Err(Error::StreamWrite(e));
+                }
+            }
+        };
+        // Move the "forwarded bytes" counter ahead by how much we were able to send out.
+        self.fwd_cnt += Wrapping(written as u32);
+
+        // METRICS.vsock.tx_bytes_count.add(written);
+
+        // If we couldn't write the whole slice, we'll need to push the remaining data to our
+        // buffer.
+        if written < buf.len() {
+            self.tx_buf.push(&buf[written..])?;
+        }
+
+        Ok(())
+    }
+
+    /// Check if the credit information the peer has last received from us is outdated.
+    fn peer_needs_credit_update(&self) -> bool {
+        let peer_seen_free_buf =
+            Wrapping(defs::CONN_TX_BUF_SIZE) - (self.fwd_cnt - self.last_fwd_cnt_to_peer);
+        peer_seen_free_buf < Wrapping(defs::CONN_CREDIT_UPDATE_THRESHOLD)
+    }
+
+    /// Check if we need to ask the peer for a credit update before sending any more data its
+    /// way.
+    fn need_credit_update_from_peer(&self) -> bool {
+        self.peer_avail_credit() == 0
+    }
+
+    /// Get the maximum number of bytes that we can send to our peer, without overflowing its
+    /// buffer.
+    fn peer_avail_credit(&self) -> usize {
+        (Wrapping(self.peer_buf_alloc as u32) - (self.rx_cnt - self.peer_fwd_cnt)).0 as usize
+    }
+
+    /// Prepare a packet header for transmission to our peer.
+    fn init_pkt<'a>(&self, pkt: &'a mut VsockPacket) -> &'a mut VsockPacket {
+        // Make sure the header is zeroed-out first.
+        // This looks sub-optimal, but it is actually optimized-out in the compiled code to be
+        // faster than a memset().
+        for b in pkt.hdr_mut() {
+            *b = 0;
+        }
+
+        pkt.set_src_cid(self.local_cid)
+            .set_dst_cid(self.peer_cid)
+            .set_src_port(self.local_port)
+            .set_dst_port(self.peer_port)
+            .set_type(uapi::VSOCK_TYPE_STREAM)
+            .set_buf_alloc(defs::CONN_TX_BUF_SIZE)
+            .set_fwd_cnt(self.fwd_cnt.0)
+    }
+}

--- a/src/devices/src/virtio/vsock/csm/mod.rs
+++ b/src/devices/src/virtio/vsock/csm/mod.rs
@@ -1,0 +1,119 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+/// This module implements our vsock connection state machine. The heavy lifting is done by
+/// `connection::VsockConnection`, while this file only defines some constants and helper structs.
+mod connection;
+mod txbuf;
+
+pub use connection::VsockConnection;
+
+pub mod defs {
+    /// Vsock connection TX buffer capacity.
+    pub const CONN_TX_BUF_SIZE: u32 = 64 * 1024;
+
+    /// When the guest thinks we have less than this amount of free buffer space,
+    /// we will send them a credit update packet.
+    pub const CONN_CREDIT_UPDATE_THRESHOLD: u32 = 4 * 1024;
+
+    /// Connection request timeout, in millis.
+    pub const CONN_REQUEST_TIMEOUT_MS: u64 = 2000;
+
+    /// Connection graceful shutdown timeout, in millis.
+    pub const CONN_SHUTDOWN_TIMEOUT_MS: u64 = 2000;
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// Attempted to push data to a full TX buffer.
+    TxBufFull,
+    /// An I/O error occurred, when attempting to flush the connection TX buffer.
+    TxBufFlush(std::io::Error),
+    /// An I/O error occurred, when attempting to write data to the host-side stream.
+    StreamWrite(std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// A vsock connection state.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ConnState {
+    /// The connection has been initiated by the host end, but is yet to be confirmed by the guest.
+    LocalInit,
+    /// The connection has been initiated by the guest, but we are yet to confirm it, by sending
+    /// a response packet (VSOCK_OP_RESPONSE).
+    PeerInit,
+    /// The connection handshake has been performed successfully, and data can now be exchanged.
+    Established,
+    /// The host (AF_UNIX) socket was closed.
+    LocalClosed,
+    /// A VSOCK_OP_SHUTDOWN packet was received from the guest. The tuple represents the guest R/W
+    /// indication: (will_not_recv_anymore_data, will_not_send_anymore_data).
+    PeerClosed(bool, bool),
+    /// The connection is scheduled to be forcefully terminated as soon as possible.
+    Killed,
+}
+
+/// An RX indication, used by `VsockConnection` to schedule future `recv_pkt()` responses.
+/// For instance, after being notified that there is available data to be read from the host stream
+/// (via `notify()`), the connection will store a `PendingRx::Rw` to be later inspected by
+/// `recv_pkt()`.
+#[derive(Clone, Copy, PartialEq)]
+enum PendingRx {
+    /// We need to yield a connection request packet (VSOCK_OP_REQUEST).
+    Request = 0,
+    /// We need to yield a connection response packet (VSOCK_OP_RESPONSE).
+    Response = 1,
+    /// We need to yield a forceful connection termination packet (VSOCK_OP_RST).
+    Rst = 2,
+    /// We need to yield a data packet (VSOCK_OP_RW), by reading from the AF_UNIX socket.
+    Rw = 3,
+    /// We need to yield a credit update packet (VSOCK_OP_CREDIT_UPDATE).
+    CreditUpdate = 4,
+}
+impl PendingRx {
+    /// Transform the enum value into a bitmask, that can be used for set operations.
+    fn into_mask(self) -> u16 {
+        1u16 << (self as u16)
+    }
+}
+
+/// A set of RX indications (`PendingRx` items).
+struct PendingRxSet {
+    data: u16,
+}
+
+impl PendingRxSet {
+    /// Insert an item into the set.
+    fn insert(&mut self, it: PendingRx) {
+        self.data |= it.into_mask();
+    }
+
+    /// Remove an item from the set and return:
+    /// - true, if the item was in the set; or
+    /// - false, if the item wasn't in the set.
+    fn remove(&mut self, it: PendingRx) -> bool {
+        let ret = self.contains(it);
+        self.data &= !it.into_mask();
+        ret
+    }
+
+    /// Check if an item is present in this set.
+    fn contains(&self, it: PendingRx) -> bool {
+        self.data & it.into_mask() != 0
+    }
+
+    /// Check if the set is empty.
+    fn is_empty(&self) -> bool {
+        self.data == 0
+    }
+}
+
+/// Create a set containing only one item.
+impl From<PendingRx> for PendingRxSet {
+    fn from(it: PendingRx) -> Self {
+        Self {
+            data: it.into_mask(),
+        }
+    }
+}

--- a/src/devices/src/virtio/vsock/csm/txbuf.rs
+++ b/src/devices/src/virtio/vsock/csm/txbuf.rs
@@ -1,0 +1,266 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Write;
+use std::num::Wrapping;
+
+use super::defs;
+use super::{Error, Result};
+
+/// A simple ring-buffer implementation, used by vsock connections to buffer TX (guest -> host)
+/// data.  Memory for this buffer is allocated lazily, since buffering will only be needed when
+/// the host can't read fast enough.
+pub struct TxBuf {
+    /// The actual u8 buffer - only allocated after the first push.
+    data: Option<Box<[u8]>>,
+    /// Ring-buffer head offset - where new data is pushed to.
+    head: Wrapping<u32>,
+    /// Ring-buffer tail offset - where data is flushed from.
+    tail: Wrapping<u32>,
+}
+
+impl TxBuf {
+    /// Total buffer size, in bytes.
+    const SIZE: usize = defs::CONN_TX_BUF_SIZE as usize;
+
+    /// Ring-buffer constructor.
+    pub fn new() -> Self {
+        Self {
+            data: None,
+            head: Wrapping(0),
+            tail: Wrapping(0),
+        }
+    }
+
+    /// Get the used length of this buffer - number of bytes that have been pushed in, but not
+    /// yet flushed out.
+    pub fn len(&self) -> usize {
+        (self.head - self.tail).0 as usize
+    }
+
+    /// Push a byte slice onto the ring-buffer.
+    ///
+    /// Either the entire source slice will be pushed to the ring-buffer, or none of it, if
+    /// there isn't enough room, in which case `Err(Error::TxBufFull)` is returned.
+    pub fn push(&mut self, src: &[u8]) -> Result<()> {
+        // Error out if there's no room to push the entire slice.
+        if self.len() + src.len() > Self::SIZE {
+            return Err(Error::TxBufFull);
+        }
+
+        let data = self
+            .data
+            .get_or_insert_with(|| vec![0u8; Self::SIZE].into_boxed_slice());
+
+        // Buffer head, as an offset into the data slice.
+        let head_ofs = self.head.0 as usize % Self::SIZE;
+
+        // Pushing a slice to this buffer can take either one or two slice copies: - one copy,
+        // if the slice fits between `head_ofs` and `Self::SIZE`; or - two copies, if the
+        // ring-buffer head wraps around.
+
+        // First copy length: we can only go from the head offset up to the total buffer size.
+        let len = std::cmp::min(Self::SIZE - head_ofs, src.len());
+        data[head_ofs..(head_ofs + len)].copy_from_slice(&src[..len]);
+
+        // If the slice didn't fit, the buffer head will wrap around, and pushing continues
+        // from the start of the buffer (`&self.data[0]`).
+        if len < src.len() {
+            data[..(src.len() - len)].copy_from_slice(&src[len..]);
+        }
+
+        // Either way, we've just pushed exactly `src.len()` bytes, so that's the amount by
+        // which the (wrapping) buffer head needs to move forward.
+        self.head += Wrapping(src.len() as u32);
+
+        Ok(())
+    }
+
+    /// Flush the contents of the ring-buffer to a writable stream.
+    ///
+    /// Return the number of bytes that have been transferred out of the ring-buffer and into
+    /// the writable stream.
+    pub fn flush_to<W>(&mut self, sink: &mut W) -> Result<usize>
+    where
+        W: Write,
+    {
+        // Nothing to do, if this buffer holds no data.
+        if self.is_empty() {
+            return Ok(0);
+        }
+
+        // Buffer tail, as an offset into the buffer data slice.
+        let tail_ofs = self.tail.0 as usize % Self::SIZE;
+
+        // Flushing the buffer can take either one or two writes:
+        // - one write, if the tail doesn't need to wrap around to reach the head; or
+        // - two writes, if the tail would wrap around: tail to slice end, then slice end to
+        //   head.
+
+        // First write length: the lesser of tail to slice end, or tail to head.
+        let len_to_write = std::cmp::min(Self::SIZE - tail_ofs, self.len());
+
+        // It's safe to unwrap here, since we've already checked if the buffer was empty.
+        let data = self.data.as_ref().unwrap();
+
+        // Issue the first write and absorb any `WouldBlock` error (we can just try again
+        // later).
+        let written = sink
+            .write(&data[tail_ofs..(tail_ofs + len_to_write)])
+            .map_err(Error::TxBufFlush)?;
+
+        // Move the buffer tail ahead by the amount (of bytes) we were able to flush out.
+        self.tail += Wrapping(written as u32);
+
+        // If we weren't able to flush out as much as we tried, there's no point in attempting
+        // our second write.
+        if written < len_to_write {
+            return Ok(written);
+        }
+
+        // Attempt our second write. This will return immediately if a second write isn't
+        // needed, since checking for an empty buffer is the first thing we do in this
+        // function.
+        //
+        // Interesting corner case: if we've already written some data in the first pass,
+        // and then the second write fails, we will consider the flush action a success
+        // and return the number of bytes written in the first pass.
+        Ok(written + self.flush_to(sink).unwrap_or(0))
+    }
+
+    /// Check if the buffer holds any data that hasn't yet been flushed out.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Error as IoError;
+    use std::io::Result as IoResult;
+    use std::io::{ErrorKind, Write};
+
+    struct TestSink {
+        data: Vec<u8>,
+        err: Option<IoError>,
+        capacity: usize,
+    }
+
+    impl TestSink {
+        const DEFAULT_CAPACITY: usize = 2 * TxBuf::SIZE;
+        fn new() -> Self {
+            Self {
+                data: Vec::with_capacity(Self::DEFAULT_CAPACITY),
+                err: None,
+                capacity: Self::DEFAULT_CAPACITY,
+            }
+        }
+    }
+
+    impl Write for TestSink {
+        fn write(&mut self, src: &[u8]) -> IoResult<usize> {
+            if self.err.is_some() {
+                return Err(self.err.take().unwrap());
+            }
+            let len_to_push = std::cmp::min(self.capacity - self.data.len(), src.len());
+            self.data.extend_from_slice(&src[..len_to_push]);
+            Ok(len_to_push)
+        }
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+    }
+
+    impl TestSink {
+        fn clear(&mut self) {
+            self.data = Vec::with_capacity(self.capacity);
+            self.err = None;
+        }
+        fn set_err(&mut self, err: IoError) {
+            self.err = Some(err);
+        }
+        fn set_capacity(&mut self, capacity: usize) {
+            self.capacity = capacity;
+            if self.data.len() > self.capacity {
+                self.data.resize(self.capacity, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_push_nowrap() {
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+        assert!(txbuf.is_empty());
+
+        assert!(txbuf.data.is_none());
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        txbuf.push(&[5, 6, 7, 8]).unwrap();
+        txbuf.flush_to(&mut sink).unwrap();
+        assert_eq!(sink.data, [1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn test_push_wrap() {
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+        let mut tmp: Vec<u8> = Vec::new();
+
+        tmp.resize(TxBuf::SIZE - 2, 0);
+        txbuf.push(tmp.as_slice()).unwrap();
+        txbuf.flush_to(&mut sink).unwrap();
+        sink.clear();
+
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 4);
+        assert_eq!(sink.data, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_push_error() {
+        let mut txbuf = TxBuf::new();
+        let mut tmp = Vec::with_capacity(TxBuf::SIZE);
+
+        tmp.resize(TxBuf::SIZE - 1, 0);
+        txbuf.push(tmp.as_slice()).unwrap();
+        match txbuf.push(&[1, 2]) {
+            Err(Error::TxBufFull) => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_incomplete_flush() {
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+
+        sink.set_capacity(2);
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 2);
+        assert_eq!(txbuf.len(), 2);
+        assert_eq!(sink.data, [1, 2]);
+
+        sink.set_capacity(4);
+        assert_eq!(txbuf.flush_to(&mut sink).unwrap(), 2);
+        assert!(txbuf.is_empty());
+        assert_eq!(sink.data, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_flush_error() {
+        const EACCESS: i32 = 13;
+
+        let mut txbuf = TxBuf::new();
+        let mut sink = TestSink::new();
+
+        txbuf.push(&[1, 2, 3, 4]).unwrap();
+        let io_err = IoError::from_raw_os_error(EACCESS);
+        sink.set_err(io_err);
+        match txbuf.flush_to(&mut sink) {
+            Err(Error::TxBufFlush(ref err)) if err.kind() == ErrorKind::PermissionDenied => (),
+            other => panic!("Unexpected result: {:?}", other),
+        }
+    }
+}

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -1,0 +1,148 @@
+use std::borrow::{Borrow, BorrowMut};
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
+
+use vm_device::bus::MmioAddress;
+use vm_device::device_manager::MmioManager;
+use vm_device::{DeviceMmio, MutDeviceMmio};
+use vm_memory::GuestAddressSpace;
+use vm_virtio::device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
+use vm_virtio::Queue;
+
+use crate::virtio::features::{VIRTIO_F_IN_ORDER, VIRTIO_F_VERSION_1};
+use crate::virtio::{CommonConfig, Env, Error as VirtioError, SingleFdSignalQueue, QUEUE_MAX_SIZE};
+
+use super::inorder_handler::InOrderHandler;
+use super::queue_handler::QueueHandler;
+use super::{Result, VsockBackend, VsockError as Error, VSOCK_DEVICE_ID};
+
+pub struct Vsock<M: GuestAddressSpace, B> {
+    cfg: CommonConfig<M>,
+    // Will likely be used in the future (i.e. when saving state).
+    _cid: u64,
+    backend: Option<B>,
+}
+
+impl<M, B> Vsock<M, B>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    B: VsockBackend + Send + 'static,
+{
+    pub fn new<Bus>(env: &mut Env<M, Bus>, cid: u64, backend: B) -> Result<Arc<Mutex<Self>>>
+    where
+        // We're using this (more convoluted) bound so we can pass both references and smart
+        // pointers such as mutex guards here.
+        Bus: DerefMut,
+        Bus::Target: MmioManager<D = Arc<dyn DeviceMmio + Send + Sync>>,
+    {
+        // TODO: `VIRTIO_F_RING_EVENT_IDX` support is not negotiated in the initial iteration.
+        // Add this as well in the next one.
+        let device_features = (1 << VIRTIO_F_VERSION_1) | (1 << VIRTIO_F_IN_ORDER);
+
+        // An rx/tx queue pair. There's a 3rd queue for events as well, but it's not
+        // supported during device operation for now.
+        let queues = vec![Queue::new(env.mem.clone(), QUEUE_MAX_SIZE); 3];
+
+        // Explicitly using `u64::from` here to ensure we're calling `to_le_bytes` on an `u64`.
+        let config_space = u64::from(cid).to_le_bytes().to_vec();
+
+        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
+
+        let common_cfg = CommonConfig::new(virtio_cfg, env).map_err(Error::Virtio)?;
+
+        let vsock = Arc::new(Mutex::new(Vsock {
+            cfg: common_cfg,
+            _cid: cid,
+            backend: Some(backend),
+        }));
+
+        env.register_mmio_device(vsock.clone())
+            .map_err(Error::Virtio)?;
+
+        Ok(vsock)
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static, B> VirtioDeviceType for Vsock<M, B> {
+    fn device_type(&self) -> u32 {
+        VSOCK_DEVICE_ID
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static, B> Borrow<VirtioConfig<M>> for Vsock<M, B> {
+    fn borrow(&self) -> &VirtioConfig<M> {
+        &self.cfg.virtio
+    }
+}
+
+impl<M: GuestAddressSpace + Clone + Send + 'static, B> BorrowMut<VirtioConfig<M>> for Vsock<M, B> {
+    fn borrow_mut(&mut self) -> &mut VirtioConfig<M> {
+        &mut self.cfg.virtio
+    }
+}
+
+impl<M, B> VirtioDeviceActions for Vsock<M, B>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    B: VsockBackend + 'static,
+{
+    type E = Error;
+
+    fn activate(&mut self) -> Result<()> {
+        let backend = self
+            .backend
+            .take()
+            .ok_or(Error::Virtio(VirtioError::AlreadyActivated))?;
+
+        let rxq = self.cfg.virtio.queues[0].clone();
+        let txq = self.cfg.virtio.queues[1].clone();
+
+        let driver_notify = SingleFdSignalQueue {
+            irqfd: self.cfg.irqfd.clone(),
+            interrupt_status: self.cfg.virtio.interrupt_status.clone(),
+        };
+
+        let inner = InOrderHandler {
+            driver_notify,
+            rxq,
+            txq,
+            backend,
+        };
+
+        let mut ioevents = self.cfg.prepare_activate().map_err(Error::Virtio)?;
+
+        let handler = Arc::new(Mutex::new(QueueHandler {
+            inner,
+            rx_ioevent: ioevents.remove(0),
+            tx_ioevent: ioevents.remove(0),
+        }));
+
+        self.cfg.finalize_activate(handler).map_err(Error::Virtio)
+    }
+
+    fn reset(&mut self) -> std::result::Result<(), Error> {
+        // Not implemented for now.
+        Ok(())
+    }
+}
+
+impl<M, B> VirtioMmioDevice<M> for Vsock<M, B>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    B: VsockBackend + 'static,
+{
+}
+
+impl<M, B> MutDeviceMmio for Vsock<M, B>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    B: VsockBackend + 'static,
+{
+    fn mmio_read(&mut self, _base: MmioAddress, offset: u64, data: &mut [u8]) {
+        self.read(offset, data);
+    }
+
+    fn mmio_write(&mut self, _base: MmioAddress, offset: u64, data: &[u8]) {
+        self.write(offset, data);
+    }
+}

--- a/src/devices/src/virtio/vsock/inorder_handler.rs
+++ b/src/devices/src/virtio/vsock/inorder_handler.rs
@@ -1,0 +1,144 @@
+use std::result;
+
+use log::{debug, error, warn};
+use vm_memory::GuestAddressSpace;
+use vm_virtio::Queue;
+
+use crate::virtio::vsock::{VsockBackend, VsockPacket};
+use crate::virtio::SignalUsedQueue;
+
+const RXQ_INDEX: u16 = 0;
+const TXQ_INDEX: u16 = 1;
+
+#[derive(Debug)]
+pub enum Error {
+    Queue(vm_virtio::Error),
+}
+
+impl From<vm_virtio::Error> for Error {
+    fn from(e: vm_virtio::Error) -> Self {
+        Error::Queue(e)
+    }
+}
+
+// TODO: The event queue is not supported for now.
+pub struct InOrderHandler<M: GuestAddressSpace, S, B> {
+    pub driver_notify: S,
+    pub rxq: Queue<M>,
+    pub txq: Queue<M>,
+    pub backend: B,
+}
+
+// The following comes from Fc; have to double check if it's still something that have to be
+// solved.
+// TODO: Detect / handle queue deadlock:
+// 1. If the driver halts RX queue processing, we'll need to notify `self.backend`, so that it
+//    can unregister any EPOLLIN listeners, since otherwise it will keep spinning, unable to consume
+//    its EPOLLIN events.
+
+impl<M, S, B> InOrderHandler<M, S, B>
+where
+    M: GuestAddressSpace,
+    S: SignalUsedQueue,
+    B: VsockBackend,
+{
+    /// Walk the driver-provided RX queue buffers and attempt to fill them up with any data that we
+    /// have pending. Return `true` if descriptors have been added to the used ring, and `false`
+    /// otherwise.
+    pub fn process_rx(&mut self) -> result::Result<bool, Error> {
+        if !self.backend.has_pending_rx() {
+            return Ok(false);
+        }
+
+        debug!("vsock: process_rx()");
+
+        let mut have_used = false;
+
+        while let Some(mut chain) = self.rxq.iter()?.next() {
+            let used_len = match VsockPacket::from_rx_virtq_head(&mut chain) {
+                Ok(mut pkt) => {
+                    if self.backend.recv_pkt(&mut pkt).is_ok() {
+                        pkt.hdr().len() as u32 + pkt.len()
+                    } else {
+                        // We are using a consuming iterator over the virtio buffers, so, if we can't
+                        // fill in this buffer, we'll need to undo the last iterator step.
+                        self.rxq.go_to_previous_position();
+                        break;
+                    }
+                }
+                Err(e) => {
+                    warn!("vsock: RX queue error: {:?}", e);
+                    0
+                }
+            };
+
+            have_used = true;
+            self.rxq
+                .add_used(chain.head_index(), used_len)
+                .unwrap_or_else(|e| {
+                    error!(
+                        "Failed to add available descriptor {}: {}",
+                        chain.head_index(),
+                        e
+                    )
+                });
+        }
+
+        if have_used {
+            self.driver_notify.signal_used_queue(RXQ_INDEX);
+        }
+
+        Ok(have_used)
+    }
+
+    /// Walk the driver-provided TX queue buffers, package them up as vsock packets, and send them
+    /// to the backend for processing. Return `true` if descriptors have been added to the used
+    /// ring, and `false` otherwise.
+    pub fn process_tx(&mut self) -> result::Result<bool, Error> {
+        debug!("vsock::process_tx()");
+
+        let mut have_used = false;
+
+        while let Some(mut chain) = self.txq.iter()?.next() {
+            let pkt = match VsockPacket::from_tx_virtq_head(&mut chain) {
+                Ok(pkt) => pkt,
+                Err(e) => {
+                    error!("vsock: error reading TX packet: {:?}", e);
+                    have_used = true;
+                    self.txq
+                        .add_used(chain.head_index(), 0)
+                        .unwrap_or_else(|e| {
+                            error!(
+                                "Failed to add available descriptor {}: {}",
+                                chain.head_index(),
+                                e
+                            );
+                        });
+                    continue;
+                }
+            };
+
+            if self.backend.send_pkt(&pkt).is_err() {
+                self.txq.go_to_previous_position();
+                break;
+            }
+
+            have_used = true;
+            self.txq
+                .add_used(chain.head_index(), 0)
+                .unwrap_or_else(|e| {
+                    error!(
+                        "Failed to add available descriptor {}: {}",
+                        chain.head_index(),
+                        e
+                    );
+                });
+        }
+
+        if have_used {
+            self.driver_notify.signal_used_queue(TXQ_INDEX);
+        }
+
+        Ok(have_used)
+    }
+}

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -1,0 +1,133 @@
+// The `byte_order` module is taken from the Firecracker `utils` crate, as it's currently
+// used by the logic in `packet.rs`. We'll decide how to expose/consume this functionality
+// as the `VsockPacket` logic itself becomes a standalone building block.
+pub mod byte_order;
+pub mod csm;
+mod device;
+mod inorder_handler;
+mod packet;
+mod queue_handler;
+pub mod unix;
+
+use std::os::unix::io::AsRawFd;
+
+use vm_memory::GuestMemoryError;
+use vmm_sys_util::epoll::EventSet;
+
+use self::packet::VsockPacket;
+
+pub use self::device::Vsock;
+pub use self::unix::Error as VsockUnixBackendError;
+
+pub const VSOCK_DEVICE_ID: u32 = 19;
+
+#[derive(Debug)]
+pub enum VsockError {
+    /// The vsock data/buffer virtio descriptor length is smaller than expected.
+    BufDescTooSmall,
+    /// The vsock data/buffer virtio descriptor is expected, but missing.
+    BufDescMissing,
+    /// EventFd error
+    EventFd(std::io::Error),
+    /// Chained GuestMemoryMmap error.
+    GuestMemoryMmap(GuestMemoryError),
+    /// Bounds check failed on guest memory pointer.
+    GuestMemoryBounds,
+    /// The vsock header virtio descriptor is expected, but missing.
+    HdrDescMissing,
+    /// The vsock header descriptor length is too small.
+    HdrDescTooSmall(u32),
+    /// The vsock header `len` field holds an invalid value.
+    InvalidPktLen(u32),
+    /// A data fetch was attempted when no data was available.
+    NoData,
+    /// A data buffer was expected for the provided packet, but it is missing.
+    PktBufMissing,
+    /// Encountered an unexpected write-only virtio descriptor.
+    UnreadableDescriptor,
+    /// Encountered an unexpected read-only virtio descriptor.
+    UnwritableDescriptor,
+    Virtio(crate::virtio::Error),
+    VsockUdsBackend(VsockUnixBackendError),
+}
+
+type Result<T> = std::result::Result<T, VsockError>;
+
+mod defs {
+    /// Max vsock packet data/buffer size.
+    pub const MAX_PKT_BUF_SIZE: usize = 64 * 1024;
+
+    pub mod uapi {
+        /// Vsock packet operation IDs.
+        /// Defined in `/include/uapi/linux/virtio_vsock.h`.
+        ///
+        /// Connection request.
+        pub const VSOCK_OP_REQUEST: u16 = 1;
+        /// Connection response.
+        pub const VSOCK_OP_RESPONSE: u16 = 2;
+        /// Connection reset.
+        pub const VSOCK_OP_RST: u16 = 3;
+        /// Connection clean shutdown.
+        pub const VSOCK_OP_SHUTDOWN: u16 = 4;
+        /// Connection data (read/write).
+        pub const VSOCK_OP_RW: u16 = 5;
+        /// Flow control credit update.
+        pub const VSOCK_OP_CREDIT_UPDATE: u16 = 6;
+        /// Flow control credit update request.
+        pub const VSOCK_OP_CREDIT_REQUEST: u16 = 7;
+
+        /// Vsock packet flags.
+        /// Defined in `/include/uapi/linux/virtio_vsock.h`.
+        ///
+        /// Valid with a VSOCK_OP_SHUTDOWN packet: the packet sender will receive no more data.
+        pub const VSOCK_FLAGS_SHUTDOWN_RCV: u32 = 1;
+        /// Valid with a VSOCK_OP_SHUTDOWN packet: the packet sender will send no more data.
+        pub const VSOCK_FLAGS_SHUTDOWN_SEND: u32 = 2;
+
+        /// Vsock packet type.
+        /// Defined in `/include/uapi/linux/virtio_vsock.h`.
+        ///
+        /// Stream / connection-oriented packet (the only currently valid type).
+        pub const VSOCK_TYPE_STREAM: u16 = 1;
+
+        pub const VSOCK_HOST_CID: u64 = 2;
+    }
+}
+
+/// A passive, event-driven object, that needs to be notified whenever an epoll-able event occurs.
+/// An event-polling control loop will use `as_raw_fd()` and `get_polled_evset()` to query
+/// the listener for the file descriptor and the set of events it's interested in. When such an
+/// event occurs, the control loop will route the event to the listener via `notify()`.
+pub trait VsockEpollListener: AsRawFd {
+    /// Get the set of events for which the listener wants to be notified.
+    fn get_polled_evset(&self) -> EventSet;
+
+    /// Notify the listener that one ore more events have occurred.
+    fn notify(&mut self, evset: EventSet);
+}
+
+/// Any channel that handles vsock packet traffic: sending and receiving packets. Since we're
+/// implementing the device model here, our responsibility is to always process the sending of
+/// packets (i.e. the TX queue). So, any locally generated data, addressed to the driver (e.g.
+/// a connection response or RST), will have to be queued, until we get to processing the RX queue.
+///
+/// Note: `recv_pkt()` and `send_pkt()` are named analogous to `Read::read()` and `Write::write()`,
+///       respectively. I.e.
+///       - `recv_pkt(&mut pkt)` will read data from the channel, and place it into `pkt`; and
+///       - `send_pkt(&pkt)` will fetch data from `pkt`, and place it into the channel.
+pub trait VsockChannel {
+    /// Read/receive an incoming packet from the channel.
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> Result<()>;
+
+    /// Write/send a packet through the channel.
+    fn send_pkt(&mut self, pkt: &VsockPacket) -> Result<()>;
+
+    /// Checks whether there is pending incoming data inside the channel, meaning that a subsequent
+    /// call to `recv_pkt()` won't fail.
+    fn has_pending_rx(&self) -> bool;
+}
+
+/// The vsock backend, which is basically an epoll-event-driven vsock channel.
+/// Currently, the only implementation we have is `crate::virtio::unix::muxer::VsockMuxer`, which
+/// translates guest-side vsock connections to host-side Unix domain socket connections.
+pub trait VsockBackend: VsockChannel + VsockEpollListener + Send {}

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -1,0 +1,346 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `VsockPacket` provides a thin wrapper over the buffers exchanged via virtio queues.
+/// There are two components to a vsock packet, each using its own descriptor in a
+/// virtio queue:
+/// - the packet header; and
+/// - the packet data/buffer.
+/// There is a 1:1 relation between descriptor chains and packets: the first (chain head) holds
+/// the header, and an optional second descriptor holds the data. The second descriptor is only
+/// present for data packets (VSOCK_OP_RW).
+///
+/// `VsockPacket` wraps these two buffers and provides direct access to the data stored
+/// in guest memory. This is done to avoid unnecessarily copying data from guest memory
+/// to temporary buffers, before passing it on to the vsock backend.
+use std::result;
+
+use vm_memory::{self, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryError};
+use vm_virtio::DescriptorChain;
+
+use super::{byte_order, defs};
+use super::{Result, VsockError};
+
+// The vsock packet header is defined by the C struct:
+//
+// ```C
+// struct virtio_vsock_hdr {
+//     le64 src_cid;
+//     le64 dst_cid;
+//     le32 src_port;
+//     le32 dst_port;
+//     le32 len;
+//     le16 type;
+//     le16 op;
+//     le32 flags;
+//     le32 buf_alloc;
+//     le32 fwd_cnt;
+// };
+// ```
+//
+// This structed will occupy the buffer pointed to by the head descriptor. We'll be accessing it
+// as a byte slice. To that end, we define below the offsets for each field struct, as well as the
+// packed struct size, as a bunch of `usize` consts.
+// Note that these offsets are only used privately by the `VsockPacket` struct, the public interface
+// consisting of getter and setter methods, for each struct field, that will also handle the correct
+// endianess.
+
+/// The vsock packet header struct size (when packed).
+pub const VSOCK_PKT_HDR_SIZE: usize = 44;
+
+// Source CID.
+const HDROFF_SRC_CID: usize = 0;
+
+// Destination CID.
+const HDROFF_DST_CID: usize = 8;
+
+// Source port.
+const HDROFF_SRC_PORT: usize = 16;
+
+// Destination port.
+const HDROFF_DST_PORT: usize = 20;
+
+// Data length (in bytes) - may be 0, if there is no data buffer.
+const HDROFF_LEN: usize = 24;
+
+// Socket type. Currently, only connection-oriented streams are defined by the vsock protocol.
+const HDROFF_TYPE: usize = 28;
+
+// Operation ID - one of the VSOCK_OP_* values; e.g.
+// - VSOCK_OP_RW: a data packet;
+// - VSOCK_OP_REQUEST: connection request;
+// - VSOCK_OP_RST: forcefull connection termination;
+// etc (see `super::defs::uapi` for the full list).
+const HDROFF_OP: usize = 30;
+
+// Additional options (flags) associated with the current operation (`op`).
+// Currently, only used with shutdown requests (VSOCK_OP_SHUTDOWN).
+const HDROFF_FLAGS: usize = 32;
+
+// Size (in bytes) of the packet sender receive buffer (for the connection to which this packet
+// belongs).
+const HDROFF_BUF_ALLOC: usize = 36;
+
+// Number of bytes the sender has received and consumed (for the connection to which this packet
+// belongs). For instance, for our Unix backend, this counter would be the total number of bytes
+// we have successfully written to a backing Unix socket.
+const HDROFF_FWD_CNT: usize = 40;
+
+/// The vsock packet, implemented as a wrapper over a virtq descriptor chain:
+/// - the chain head, holding the packet header; and
+/// - (an optional) data/buffer descriptor, only present for data packets (VSOCK_OP_RW).
+pub struct VsockPacket {
+    hdr: *mut u8,
+    buf: Option<*mut u8>,
+    buf_size: usize,
+}
+
+fn get_host_address<T: GuestMemory>(
+    mem: &T,
+    guest_addr: GuestAddress,
+    size: usize,
+) -> result::Result<*mut u8, GuestMemoryError> {
+    Ok(mem.get_slice(guest_addr, size)?.as_ptr())
+}
+
+impl VsockPacket {
+    /// Create the packet wrapper from a TX virtq chain head.
+    ///
+    /// The chain head is expected to hold valid packet header data. A following packet buffer
+    /// descriptor can optionally end the chain. Bounds and pointer checks are performed when
+    /// creating the wrapper.
+    pub fn from_tx_virtq_head<M: GuestAddressSpace>(
+        chain: &mut DescriptorChain<M>,
+    ) -> Result<Self> {
+        let desc = chain.next().ok_or(VsockError::HdrDescMissing)?;
+
+        // All buffers in the TX queue must be readable.
+        //
+        if desc.is_write_only() {
+            return Err(VsockError::UnreadableDescriptor);
+        }
+
+        // The packet header should fit inside the head descriptor.
+        if desc.len() < VSOCK_PKT_HDR_SIZE as u32 {
+            return Err(VsockError::HdrDescTooSmall(desc.len()));
+        }
+
+        let mut pkt = Self {
+            hdr: get_host_address(chain.memory(), desc.addr(), VSOCK_PKT_HDR_SIZE)
+                .map_err(VsockError::GuestMemoryMmap)?,
+            buf: None,
+            buf_size: 0,
+        };
+
+        // No point looking for a data/buffer descriptor, if the packet is zero-lengthed.
+        if pkt.len() == 0 {
+            return Ok(pkt);
+        }
+
+        // Reject weirdly-sized packets.
+        //
+        if pkt.len() > defs::MAX_PKT_BUF_SIZE as u32 {
+            return Err(VsockError::InvalidPktLen(pkt.len()));
+        }
+
+        // If the packet header showed a non-zero length, there should be a data descriptor here.
+        let buf_desc = chain.next().ok_or(VsockError::BufDescMissing)?;
+
+        // TX data should be read-only.
+        if buf_desc.is_write_only() {
+            return Err(VsockError::UnreadableDescriptor);
+        }
+
+        // The data buffer should be large enough to fit the size of the data, as described by
+        // the header descriptor.
+        if buf_desc.len() < pkt.len() {
+            return Err(VsockError::BufDescTooSmall);
+        }
+
+        pkt.buf_size = buf_desc.len() as usize;
+        pkt.buf = Some(
+            get_host_address(chain.memory(), buf_desc.addr(), pkt.buf_size)
+                .map_err(VsockError::GuestMemoryMmap)?,
+        );
+
+        Ok(pkt)
+    }
+
+    /// Create the packet wrapper from an RX virtq chain head.
+    ///
+    /// There must be two descriptors in the chain, both writable: a header descriptor and a data
+    /// descriptor. Bounds and pointer checks are performed when creating the wrapper.
+    pub fn from_rx_virtq_head<M: GuestAddressSpace>(
+        chain: &mut DescriptorChain<M>,
+    ) -> Result<Self> {
+        let desc = chain.next().ok_or(VsockError::HdrDescMissing)?;
+
+        // All RX buffers must be writable.
+        //
+        if !desc.is_write_only() {
+            return Err(VsockError::UnwritableDescriptor);
+        }
+
+        // The packet header should fit inside the head descriptor.
+        if desc.len() < VSOCK_PKT_HDR_SIZE as u32 {
+            return Err(VsockError::HdrDescTooSmall(desc.len()));
+        }
+
+        // All RX descriptor chains should have a header and a data descriptor.
+        if !desc.has_next() {
+            return Err(VsockError::BufDescMissing);
+        }
+        let buf_desc = chain.next().ok_or(VsockError::BufDescMissing)?;
+        let buf_size = buf_desc.len() as usize;
+
+        Ok(Self {
+            hdr: get_host_address(chain.memory(), desc.addr(), VSOCK_PKT_HDR_SIZE)
+                .map_err(VsockError::GuestMemoryMmap)?,
+            buf: Some(
+                get_host_address(chain.memory(), buf_desc.addr(), buf_size)
+                    .map_err(VsockError::GuestMemoryMmap)?,
+            ),
+            buf_size,
+        })
+    }
+
+    /// Provides in-place, byte-slice, access to the vsock packet header.
+    pub fn hdr(&self) -> &[u8] {
+        // This is safe since bound checks have already been performed when creating the packet
+        // from the virtq descriptor.
+        unsafe { std::slice::from_raw_parts(self.hdr as *const u8, VSOCK_PKT_HDR_SIZE) }
+    }
+
+    /// Provides in-place, byte-slice, mutable access to the vsock packet header.
+    pub fn hdr_mut(&mut self) -> &mut [u8] {
+        // This is safe since bound checks have already been performed when creating the packet
+        // from the virtq descriptor.
+        unsafe { std::slice::from_raw_parts_mut(self.hdr, VSOCK_PKT_HDR_SIZE) }
+    }
+
+    /// Provides in-place, byte-slice access to the vsock packet data buffer.
+    ///
+    /// Note: control packets (e.g. connection request or reset) have no data buffer associated.
+    ///       For those packets, this method will return `None`.
+    /// Also note: calling `len()` on the returned slice will yield the buffer size, which may be
+    ///            (and often is) larger than the length of the packet data. The packet data length
+    ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
+    pub fn buf(&self) -> Option<&[u8]> {
+        self.buf.map(|ptr| {
+            // This is safe since bound checks have already been performed when creating the packet
+            // from the virtq descriptor.
+            unsafe { std::slice::from_raw_parts(ptr as *const u8, self.buf_size) }
+        })
+    }
+
+    /// Provides in-place, byte-slice, mutable access to the vsock packet data buffer.
+    ///
+    /// Note: control packets (e.g. connection request or reset) have no data buffer associated.
+    ///       For those packets, this method will return `None`.
+    /// Also note: calling `len()` on the returned slice will yield the buffer size, which may be
+    ///            (and often is) larger than the length of the packet data. The packet data length
+    ///            is stored in the packet header, and accessible via `VsockPacket::len()`.
+    pub fn buf_mut(&mut self) -> Option<&mut [u8]> {
+        self.buf.map(|ptr| {
+            // This is safe since bound checks have already been performed when creating the packet
+            // from the virtq descriptor.
+            unsafe { std::slice::from_raw_parts_mut(ptr, self.buf_size) }
+        })
+    }
+
+    pub fn src_cid(&self) -> u64 {
+        byte_order::read_le_u64(&self.hdr()[HDROFF_SRC_CID..])
+    }
+
+    pub fn set_src_cid(&mut self, cid: u64) -> &mut Self {
+        byte_order::write_le_u64(&mut self.hdr_mut()[HDROFF_SRC_CID..], cid);
+        self
+    }
+
+    pub fn dst_cid(&self) -> u64 {
+        byte_order::read_le_u64(&self.hdr()[HDROFF_DST_CID..])
+    }
+
+    pub fn set_dst_cid(&mut self, cid: u64) -> &mut Self {
+        byte_order::write_le_u64(&mut self.hdr_mut()[HDROFF_DST_CID..], cid);
+        self
+    }
+
+    pub fn src_port(&self) -> u32 {
+        byte_order::read_le_u32(&self.hdr()[HDROFF_SRC_PORT..])
+    }
+
+    pub fn set_src_port(&mut self, port: u32) -> &mut Self {
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_SRC_PORT..], port);
+        self
+    }
+
+    pub fn dst_port(&self) -> u32 {
+        byte_order::read_le_u32(&self.hdr()[HDROFF_DST_PORT..])
+    }
+
+    pub fn set_dst_port(&mut self, port: u32) -> &mut Self {
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_DST_PORT..], port);
+        self
+    }
+
+    pub fn len(&self) -> u32 {
+        byte_order::read_le_u32(&self.hdr()[HDROFF_LEN..])
+    }
+
+    pub fn set_len(&mut self, len: u32) -> &mut Self {
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_LEN..], len);
+        self
+    }
+
+    pub fn type_(&self) -> u16 {
+        byte_order::read_le_u16(&self.hdr()[HDROFF_TYPE..])
+    }
+
+    pub fn set_type(&mut self, type_: u16) -> &mut Self {
+        byte_order::write_le_u16(&mut self.hdr_mut()[HDROFF_TYPE..], type_);
+        self
+    }
+
+    pub fn op(&self) -> u16 {
+        byte_order::read_le_u16(&self.hdr()[HDROFF_OP..])
+    }
+
+    pub fn set_op(&mut self, op: u16) -> &mut Self {
+        byte_order::write_le_u16(&mut self.hdr_mut()[HDROFF_OP..], op);
+        self
+    }
+
+    pub fn flags(&self) -> u32 {
+        byte_order::read_le_u32(&self.hdr()[HDROFF_FLAGS..])
+    }
+
+    pub fn set_flags(&mut self, flags: u32) -> &mut Self {
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_FLAGS..], flags);
+        self
+    }
+
+    pub fn set_flag(&mut self, flag: u32) -> &mut Self {
+        self.set_flags(self.flags() | flag);
+        self
+    }
+
+    pub fn buf_alloc(&self) -> u32 {
+        byte_order::read_le_u32(&self.hdr()[HDROFF_BUF_ALLOC..])
+    }
+
+    pub fn set_buf_alloc(&mut self, buf_alloc: u32) -> &mut Self {
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_BUF_ALLOC..], buf_alloc);
+        self
+    }
+
+    pub fn fwd_cnt(&self) -> u32 {
+        byte_order::read_le_u32(&self.hdr()[HDROFF_FWD_CNT..])
+    }
+
+    pub fn set_fwd_cnt(&mut self, fwd_cnt: u32) -> &mut Self {
+        byte_order::write_le_u32(&mut self.hdr_mut()[HDROFF_FWD_CNT..], fwd_cnt);
+        self
+    }
+}

--- a/src/devices/src/virtio/vsock/queue_handler.rs
+++ b/src/devices/src/virtio/vsock/queue_handler.rs
@@ -1,0 +1,136 @@
+use event_manager::{EventOps, Events, MutEventSubscriber};
+use log::{error, warn};
+use vm_memory::GuestAddressSpace;
+use vmm_sys_util::epoll::EventSet;
+use vmm_sys_util::eventfd::EventFd;
+
+use crate::virtio::vsock::VsockBackend;
+use crate::virtio::SingleFdSignalQueue;
+
+use super::inorder_handler::InOrderHandler;
+
+const BACKEND_DATA: u32 = 0;
+const RX_IOEVENT_DATA: u32 = 1;
+const TX_IOEVENT_DATA: u32 = 2;
+
+pub struct QueueHandler<M: GuestAddressSpace, B> {
+    pub inner: InOrderHandler<M, SingleFdSignalQueue, B>,
+    pub rx_ioevent: EventFd,
+    pub tx_ioevent: EventFd,
+}
+
+impl<M, B> QueueHandler<M, B>
+where
+    M: GuestAddressSpace,
+    B: VsockBackend,
+{
+    fn handle_rxq_event(&mut self, event_set: EventSet) -> bool {
+        if event_set != EventSet::IN {
+            warn!("vsock: rxq unexpected event {:?}", event_set);
+            return false;
+        }
+
+        if let Err(e) = self.rx_ioevent.read() {
+            warn!("Failed to get vsock rx queue event: {:?}", e);
+            return false;
+        }
+
+        if let Err(e) = self.inner.process_rx() {
+            error!("vosck: process_rx error {:?}", e);
+            return false;
+        }
+
+        true
+    }
+
+    fn process_tx_and_rx(&mut self) -> bool {
+        if let Err(e) = self.inner.process_tx() {
+            error!("vsock: process_tx error {:?}", e);
+            return false;
+        }
+
+        // The backend may have queued up responses to the packets we sent during
+        // TX queue processing. If that happened, we need to fetch those responses
+        // and place them into RX buffers.
+        if let Err(e) = self.inner.process_rx() {
+            error!("vosck: process_rx error {:?}", e);
+            return false;
+        }
+
+        true
+    }
+
+    fn handle_txq_event(&mut self, event_set: EventSet) -> bool {
+        if event_set != EventSet::IN {
+            warn!("vsock: txq unexpected event {:?}", event_set);
+            return false;
+        }
+
+        if let Err(e) = self.tx_ioevent.read() {
+            error!("Failed to get vsock tx queue event: {:?}", e);
+            return false;
+        }
+
+        self.process_tx_and_rx()
+    }
+
+    fn notify_backend(&mut self, event_set: EventSet) -> bool {
+        self.inner.backend.notify(event_set);
+        // After the backend has been kicked, it might've freed up some resources, so we
+        // can attempt to send it more data to process. In particular, if `backend.send_pkt()`
+        // halted the TX queue processing at some point in the past, now is the time to try
+        // walking the  TX queue again.
+        self.process_tx_and_rx()
+    }
+}
+
+impl<M, B> MutEventSubscriber for QueueHandler<M, B>
+where
+    M: GuestAddressSpace,
+    B: VsockBackend,
+{
+    fn process(&mut self, events: Events, ops: &mut EventOps) {
+        let event_set = events.event_set();
+        let is_ok = match events.data() {
+            RX_IOEVENT_DATA => self.handle_rxq_event(event_set),
+            TX_IOEVENT_DATA => self.handle_txq_event(event_set),
+            BACKEND_DATA => self.notify_backend(event_set),
+            _ => {
+                error!("vsock: invalid events.data()");
+                false
+            }
+        };
+
+        // On error, unsubscribe the device events to stop all processing.
+        if !is_ok {
+            // TODO: Is there a nicer way of performing the unsubscription?
+            ops.remove(Events::empty(&self.rx_ioevent))
+                .and(ops.remove(Events::empty(&self.tx_ioevent)))
+                .and(ops.remove(Events::empty(&self.inner.backend)))
+                .expect("failed to remove vsock events");
+        }
+    }
+
+    fn init(&mut self, ops: &mut EventOps) {
+        ops.add(Events::with_data(
+            &self.inner.backend,
+            BACKEND_DATA,
+            self.inner.backend.get_polled_evset(),
+        ))
+        .expect("unable to add backend events");
+
+        ops.add(Events::with_data(
+            &self.rx_ioevent,
+            RX_IOEVENT_DATA,
+            EventSet::IN,
+        ))
+        .expect("unable to add rxfd");
+
+        ops.add(Events::with_data(
+            &self.tx_ioevent,
+            TX_IOEVENT_DATA,
+            EventSet::IN,
+        ))
+        .expect("unable to add txfd");
+    }
+}

--- a/src/devices/src/virtio/vsock/unix/mod.rs
+++ b/src/devices/src/virtio/vsock/unix/mod.rs
@@ -1,0 +1,48 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// This module implements the Unix Domain Sockets backend for vsock - a mediator between
+/// guest-side AF_VSOCK sockets and host-side AF_UNIX sockets. The heavy lifting is performed by
+/// `muxer::VsockMuxer`, a connection multiplexer that uses `super::csm::VsockConnection` for
+/// handling vsock connection states.
+/// Check out `muxer.rs` for a more detailed explanation of the inner workings of this backend.
+mod muxer;
+mod muxer_killq;
+mod muxer_rxq;
+
+pub use muxer::VsockMuxer as VsockUnixBackend;
+
+mod defs {
+    /// Maximum number of established connections that we can handle.
+    pub const MAX_CONNECTIONS: usize = 1023;
+
+    /// Size of the muxer RX packet queue.
+    pub const MUXER_RXQ_SIZE: usize = 256;
+
+    /// Size of the muxer connection kill queue.
+    pub const MUXER_KILLQ_SIZE: usize = 128;
+}
+
+#[derive(Debug)]
+pub enum Error {
+    /// Error registering a new epoll-listening FD.
+    EpollAdd(std::io::Error),
+    /// Error creating an epoll FD.
+    EpollFdCreate(std::io::Error),
+    /// The host made an invalid vsock port connection request.
+    InvalidPortRequest,
+    /// Error accepting a new connection from the host-side Unix socket.
+    UnixAccept(std::io::Error),
+    /// Error binding to the host-side Unix socket.
+    UnixBind(std::io::Error),
+    /// Error connecting to a host-side Unix socket.
+    UnixConnect(std::io::Error),
+    /// Error reading from host-side Unix socket.
+    UnixRead(std::io::Error),
+    /// Muxer connection limit reached.
+    TooManyConnections,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+type MuxerConnection = super::csm::VsockConnection<std::os::unix::net::UnixStream>;

--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -1,0 +1,781 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `VsockMuxer` is the device-facing component of the Unix domain sockets vsock backend. I.e.
+/// by implementing the `VsockBackend` trait, it abstracts away the gory details of translating
+/// between AF_VSOCK and AF_UNIX, and presents a clean interface to the rest of the vsock
+/// device model.
+///
+/// The vsock muxer has two main roles:
+/// 1. Vsock connection multiplexer:
+///    It's the muxer's job to create, manage, and terminate `VsockConnection` objects. The
+///    muxer also routes packets to their owning connections. It does so via a connection
+///    `HashMap`, keyed by what is basically a (host_port, guest_port) tuple.
+///    Vsock packet traffic needs to be inspected, in order to detect connection request
+///    packets (leading to the creation of a new connection), and connection reset packets
+///    (leading to the termination of an existing connection). All other packets, though, must
+///    belong to an existing connection and, as such, the muxer simply forwards them.
+/// 2. Event dispatcher
+///    There are three event categories that the vsock backend is interested it:
+///    1. A new host-initiated connection is ready to be accepted from the listening host Unix
+///       socket;
+///    2. Data is available for reading from a newly-accepted host-initiated connection (i.e.
+///       the host is ready to issue a vsock connection request, informing us of the
+///       destination port to which it wants to connect);
+///    3. Some event was triggered for a connected Unix socket, that belongs to a
+///       `VsockConnection`.
+///    The muxer gets notified about all of these events, because, as a `VsockEpollListener`
+///    implementor, it gets to register a nested epoll FD into the main VMM epolling loop. All
+///    other pollable FDs are then registered under this nested epoll FD.
+///    To route all these events to their handlers, the muxer uses another `HashMap` object,
+///    mapping `RawFd`s to `EpollListener`s.
+use std::collections::{HashMap, HashSet};
+use std::io::Read;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+
+use log::{debug, error, info, warn};
+use vmm_sys_util::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
+
+use super::super::csm::ConnState;
+use super::super::defs::uapi;
+use super::super::packet::VsockPacket;
+use super::super::{
+    Result as VsockResult, VsockBackend, VsockChannel, VsockEpollListener, VsockError,
+};
+use super::defs;
+use super::muxer_killq::MuxerKillQ;
+use super::muxer_rxq::MuxerRxQ;
+use super::MuxerConnection;
+use super::{Error, Result};
+
+/// A unique identifier of a `MuxerConnection` object. Connections are stored in a hash map,
+/// keyed by a `ConnMapKey` object.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ConnMapKey {
+    local_port: u32,
+    peer_port: u32,
+}
+
+/// A muxer RX queue item.
+#[derive(Clone, Copy, Debug)]
+pub enum MuxerRx {
+    /// The packet must be fetched from the connection identified by `ConnMapKey`.
+    ConnRx(ConnMapKey),
+    /// The muxer must produce an RST packet.
+    RstPkt { local_port: u32, peer_port: u32 },
+}
+
+/// An epoll listener, registered under the muxer's nested epoll FD.
+enum EpollListener {
+    /// The listener is a `MuxerConnection`, identified by `key`, and interested in the events
+    /// in `evset`. Since `MuxerConnection` implements `VsockEpollListener`, notifications will
+    /// be forwarded to the listener via `VsockEpollListener::notify()`.
+    Connection { key: ConnMapKey, evset: EventSet },
+    /// A listener interested in new host-initiated connections.
+    HostSock,
+    /// A listener interested in reading host "connect <port>" commands from a freshly
+    /// connected host socket.
+    LocalStream(UnixStream),
+}
+
+/// The vsock connection multiplexer.
+pub struct VsockMuxer {
+    /// Guest CID.
+    cid: u64,
+    /// A hash map used to store the active connections.
+    conn_map: HashMap<ConnMapKey, MuxerConnection>,
+    /// A hash map used to store epoll event listeners / handlers.
+    listener_map: HashMap<RawFd, EpollListener>,
+    /// The RX queue. Items in this queue are consumed by `VsockMuxer::recv_pkt()`, and
+    /// produced
+    /// - by `VsockMuxer::send_pkt()` (e.g. RST in response to a connection request packet);
+    ///   and
+    /// - in response to EPOLLIN events (e.g. data available to be read from an AF_UNIX
+    ///   socket).
+    rxq: MuxerRxQ,
+    /// A queue used for terminating connections that are taking too long to shut down.
+    killq: MuxerKillQ,
+    /// The Unix socket, through which host-initiated connections are accepted.
+    host_sock: UnixListener,
+    /// The file system path of the host-side Unix socket. This is used to figure out the path
+    /// to Unix sockets listening on specific ports. I.e. "<this path>_<port number>".
+    pub(crate) host_sock_path: PathBuf,
+    /// The nested epoll event set, used to register epoll listeners.
+    epoll: Epoll,
+    /// A hash set used to keep track of used host-side (local) ports, in order to assign local
+    /// ports to host-initiated connections.
+    local_port_set: HashSet<u32>,
+    /// The last used host-side port.
+    local_port_last: u32,
+}
+
+impl VsockChannel for VsockMuxer {
+    /// Deliver a vsock packet to the guest vsock driver.
+    ///
+    /// Retuns:
+    /// - `Ok(())`: `pkt` has been successfully filled in; or
+    /// - `Err(VsockError::NoData)`: there was no available data with which to fill in the
+    ///   packet.
+    fn recv_pkt(&mut self, pkt: &mut VsockPacket) -> VsockResult<()> {
+        // We'll look for instructions on how to build the RX packet in the RX queue. If the
+        // queue is empty, that doesn't necessarily mean we don't have any pending RX, since
+        // the queue might be out-of-sync. If that's the case, we'll attempt to sync it first,
+        // and then try to pop something out again.
+        if self.rxq.is_empty() && !self.rxq.is_synced() {
+            self.rxq = MuxerRxQ::from_conn_map(&self.conn_map);
+        }
+
+        while let Some(rx) = self.rxq.peek() {
+            let res = match rx {
+                // We need to build an RST packet, going from `local_port` to `peer_port`.
+                MuxerRx::RstPkt {
+                    local_port,
+                    peer_port,
+                } => {
+                    pkt.set_op(uapi::VSOCK_OP_RST)
+                        .set_src_cid(uapi::VSOCK_HOST_CID)
+                        .set_dst_cid(self.cid)
+                        .set_src_port(local_port)
+                        .set_dst_port(peer_port)
+                        .set_len(0)
+                        .set_type(uapi::VSOCK_TYPE_STREAM)
+                        .set_flags(0)
+                        .set_buf_alloc(0)
+                        .set_fwd_cnt(0);
+                    self.rxq.pop().unwrap();
+                    return Ok(());
+                }
+
+                // We'll defer building the packet to this connection, since it has something
+                // to say.
+                MuxerRx::ConnRx(key) => {
+                    let mut conn_res = Err(VsockError::NoData);
+                    let mut do_pop = true;
+                    self.apply_conn_mutation(key, |conn| {
+                        conn_res = conn.recv_pkt(pkt);
+                        do_pop = !conn.has_pending_rx();
+                    });
+                    if do_pop {
+                        self.rxq.pop().unwrap();
+                    }
+                    conn_res
+                }
+            };
+
+            if res.is_ok() {
+                // Inspect traffic, looking for RST packets, since that means we have to
+                // terminate and remove this connection from the active connection pool.
+                //
+                if pkt.op() == uapi::VSOCK_OP_RST {
+                    self.remove_connection(ConnMapKey {
+                        local_port: pkt.src_port(),
+                        peer_port: pkt.dst_port(),
+                    });
+                }
+
+                debug!("vsock muxer: RX pkt: {:?}", pkt.hdr());
+                return Ok(());
+            }
+        }
+
+        Err(VsockError::NoData)
+    }
+
+    /// Deliver a guest-generated packet to its destination in the vsock backend.
+    ///
+    /// This absorbs unexpected packets, handles RSTs (by dropping connections), and forwards
+    /// all the rest to their owning `MuxerConnection`.
+    ///
+    /// Returns:
+    /// always `Ok(())` - the packet has been consumed, and its virtio TX buffers can be
+    /// returned to the guest vsock driver.
+    fn send_pkt(&mut self, pkt: &VsockPacket) -> VsockResult<()> {
+        let conn_key = ConnMapKey {
+            local_port: pkt.dst_port(),
+            peer_port: pkt.src_port(),
+        };
+
+        debug!(
+            "vsock: muxer.send[rxq.len={}]: {:?}",
+            self.rxq.len(),
+            pkt.hdr()
+        );
+
+        // If this packet has an unsupported type (!=stream), we must send back an RST.
+        //
+        if pkt.type_() != uapi::VSOCK_TYPE_STREAM {
+            self.enq_rst(pkt.dst_port(), pkt.src_port());
+            return Ok(());
+        }
+
+        // We don't know how to handle packets addressed to other CIDs. We only handle the host
+        // part of the guest - host communication here.
+        if pkt.dst_cid() != uapi::VSOCK_HOST_CID {
+            info!(
+                "vsock: dropping guest packet for unknown CID: {:?}",
+                pkt.hdr()
+            );
+            return Ok(());
+        }
+
+        if !self.conn_map.contains_key(&conn_key) {
+            // This packet can't be routed to any active connection (based on its src and dst
+            // ports).  The only orphan / unroutable packets we know how to handle are
+            // connection requests.
+            if pkt.op() == uapi::VSOCK_OP_REQUEST {
+                // Oh, this is a connection request!
+                self.handle_peer_request_pkt(&pkt);
+            } else {
+                // Send back an RST, to let the drive know we weren't expecting this packet.
+                self.enq_rst(pkt.dst_port(), pkt.src_port());
+            }
+            return Ok(());
+        }
+
+        // Right, we know where to send this packet, then (to `conn_key`).
+        // However, if this is an RST, we have to forcefully terminate the connection, so
+        // there's no point in forwarding it the packet.
+        if pkt.op() == uapi::VSOCK_OP_RST {
+            self.remove_connection(conn_key);
+            return Ok(());
+        }
+
+        // Alright, everything looks in order - forward this packet to its owning connection.
+        let mut res: VsockResult<()> = Ok(());
+        self.apply_conn_mutation(conn_key, |conn| {
+            res = conn.send_pkt(pkt);
+        });
+
+        res
+    }
+
+    /// Check if the muxer has any pending RX data, with which to fill a guest-provided RX
+    /// buffer.
+    fn has_pending_rx(&self) -> bool {
+        !self.rxq.is_empty() || !self.rxq.is_synced()
+    }
+}
+
+impl AsRawFd for VsockMuxer {
+    /// Get the FD to be registered for polling upstream (in the main VMM epoll loop, in this
+    /// case).
+    ///
+    /// This will be the muxer's nested epoll FD.
+    fn as_raw_fd(&self) -> RawFd {
+        self.epoll.as_raw_fd()
+    }
+}
+
+impl VsockEpollListener for VsockMuxer {
+    /// Get the epoll events to be polled upstream.
+    ///
+    /// Since the polled FD is a nested epoll FD, we're only interested in EPOLLIN events (i.e.
+    /// some event occured on one of the FDs registered under our epoll FD).
+    fn get_polled_evset(&self) -> EventSet {
+        EventSet::IN
+    }
+
+    /// Notify the muxer about a pending event having occured under its nested epoll FD.
+    fn notify(&mut self, _: EventSet) {
+        debug!("vsock: muxer received kick");
+
+        let mut epoll_events = vec![EpollEvent::new(EventSet::empty(), 0); 32];
+        match self
+            .epoll
+            .wait(epoll_events.len(), 0, epoll_events.as_mut_slice())
+        {
+            Ok(ev_cnt) => {
+                for ev in &epoll_events[0..ev_cnt] {
+                    self.handle_event(
+                        ev.fd(),
+                        // It's ok to unwrap here, since the `epoll_events[i].events` is filled
+                        // in by `epoll::wait()`, and therefore contains only valid epoll
+                        // flags.
+                        EventSet::from_bits(ev.events).unwrap(),
+                    );
+                }
+            }
+            Err(e) => {
+                warn!("vsock: failed to consume muxer epoll event: {}", e);
+
+                // METRICS.vsock.muxer_event_fails.inc();
+            }
+        }
+    }
+}
+
+impl VsockBackend for VsockMuxer {}
+
+impl VsockMuxer {
+    /// Muxer constructor.
+    pub fn new(cid: u64, host_sock_path: PathBuf) -> Result<Self> {
+        // Open/bind on the host Unix socket, so we can accept host-initiated
+        // connections.
+        let host_sock = UnixListener::bind(&host_sock_path)
+            .and_then(|sock| sock.set_nonblocking(true).map(|_| sock))
+            .map_err(Error::UnixBind)?;
+
+        let mut muxer = Self {
+            cid,
+            host_sock,
+            host_sock_path,
+            epoll: Epoll::new().map_err(Error::EpollFdCreate)?,
+            rxq: MuxerRxQ::new(),
+            conn_map: HashMap::with_capacity(defs::MAX_CONNECTIONS),
+            listener_map: HashMap::with_capacity(defs::MAX_CONNECTIONS + 1),
+            killq: MuxerKillQ::new(),
+            local_port_last: (1u32 << 30) - 1,
+            local_port_set: HashSet::with_capacity(defs::MAX_CONNECTIONS),
+        };
+
+        // Listen on the host initiated socket, for incomming connections.
+        muxer.add_listener(muxer.host_sock.as_raw_fd(), EpollListener::HostSock)?;
+        Ok(muxer)
+    }
+
+    /// Handle/dispatch an epoll event to its listener.
+    fn handle_event(&mut self, fd: RawFd, evset: EventSet) {
+        debug!(
+            "vsock: muxer processing event: fd={}, evset={:?}",
+            fd, evset
+        );
+
+        match self.listener_map.get_mut(&fd) {
+            // This event needs to be forwarded to a `MuxerConnection` that is listening for
+            // it.
+            Some(EpollListener::Connection { key, evset }) => {
+                let key_copy = *key;
+                let evset_copy = *evset;
+                // The handling of this event will most probably mutate the state of the
+                // receiving conection. We'll need to check for new pending RX, event set
+                // mutation, and all that, so we're wrapping the event delivery inside those
+                // checks.
+                self.apply_conn_mutation(key_copy, |conn| {
+                    conn.notify(evset_copy);
+                });
+            }
+
+            // A new host-initiated connection is ready to be accepted.
+            Some(EpollListener::HostSock) => {
+                if self.conn_map.len() == defs::MAX_CONNECTIONS {
+                    // If we're already maxed-out on connections, we'll just accept and
+                    // immediately discard this potentially new one.
+                    warn!("vsock: connection limit reached; refusing new host connection");
+                    self.host_sock.accept().map(|_| 0).unwrap_or(0);
+                    return;
+                }
+                self.host_sock
+                    .accept()
+                    .map_err(Error::UnixAccept)
+                    .and_then(|(stream, _)| {
+                        stream
+                            .set_nonblocking(true)
+                            .map(|_| stream)
+                            .map_err(Error::UnixAccept)
+                    })
+                    .and_then(|stream| {
+                        // Before forwarding this connection to a listening AF_VSOCK socket on
+                        // the guest side, we need to know the destination port. We'll read
+                        // that port from a "connect" command received on this socket, so the
+                        // next step is to ask to be notified the moment we can read from it.
+                        self.add_listener(stream.as_raw_fd(), EpollListener::LocalStream(stream))
+                    })
+                    .unwrap_or_else(|err| {
+                        warn!("vsock: unable to accept local connection: {:?}", err);
+                    });
+            }
+
+            // Data is ready to be read from a host-initiated connection. That would be the
+            // "connect" command that we're expecting.
+            Some(EpollListener::LocalStream(_)) => {
+                if let Some(EpollListener::LocalStream(mut stream)) = self.remove_listener(fd) {
+                    Self::read_local_stream_port(&mut stream)
+                        .and_then(|peer_port| Ok((self.allocate_local_port(), peer_port)))
+                        .and_then(|(local_port, peer_port)| {
+                            self.add_connection(
+                                ConnMapKey {
+                                    local_port,
+                                    peer_port,
+                                },
+                                MuxerConnection::new_local_init(
+                                    stream,
+                                    uapi::VSOCK_HOST_CID,
+                                    self.cid,
+                                    local_port,
+                                    peer_port,
+                                ),
+                            )
+                        })
+                        .unwrap_or_else(|err| {
+                            info!("vsock: error adding local-init connection: {:?}", err);
+                        })
+                }
+            }
+
+            _ => {
+                info!("vsock: unexpected event: fd={:?}, evset={:?}", fd, evset);
+
+                // METRICS.vsock.muxer_event_fails.inc();
+            }
+        }
+    }
+
+    /// Parse a host "connect" command, and extract the destination vsock port.
+    fn read_local_stream_port(stream: &mut UnixStream) -> Result<u32> {
+        let mut buf = [0u8; 32];
+
+        // This is the minimum number of bytes that we should be able to read, when parsing a
+        // valid connection request. I.e. `b"connect 0\n".len()`.
+        const MIN_READ_LEN: usize = 10;
+
+        // Bring in the minimum number of bytes that we should be able to read.
+        stream
+            .read_exact(&mut buf[..MIN_READ_LEN])
+            .map_err(Error::UnixRead)?;
+
+        // Now, finish reading the destination port number, by bringing in one byte at a time,
+        // until we reach an EOL terminator (or our buffer space runs out).  Yeah, not
+        // particularly proud of this approach, but it will have to do for now.
+        let mut blen = MIN_READ_LEN;
+        while buf[blen - 1] != b'\n' && blen < buf.len() {
+            stream
+                .read_exact(&mut buf[blen..=blen])
+                .map_err(Error::UnixRead)?;
+            blen += 1;
+        }
+
+        let mut word_iter = std::str::from_utf8(&buf[..blen])
+            .map_err(|_| Error::InvalidPortRequest)?
+            .split_whitespace();
+
+        word_iter
+            .next()
+            .ok_or(Error::InvalidPortRequest)
+            .and_then(|word| {
+                if word.to_lowercase() == "connect" {
+                    Ok(())
+                } else {
+                    Err(Error::InvalidPortRequest)
+                }
+            })
+            .and_then(|_| word_iter.next().ok_or(Error::InvalidPortRequest))
+            .and_then(|word| word.parse::<u32>().map_err(|_| Error::InvalidPortRequest))
+            .map_err(|_| Error::InvalidPortRequest)
+    }
+
+    /// Add a new connection to the active connection pool.
+    fn add_connection(&mut self, key: ConnMapKey, conn: MuxerConnection) -> Result<()> {
+        // We might need to make room for this new connection, so let's sweep the kill queue
+        // first.  It's fine to do this here because:
+        // - unless the kill queue is out of sync, this is a pretty inexpensive operation; and
+        // - we are under no pressure to respect any accurate timing for connection
+        //   termination.
+        self.sweep_killq();
+
+        if self.conn_map.len() >= defs::MAX_CONNECTIONS {
+            info!(
+                "vsock: muxer connection limit reached ({})",
+                defs::MAX_CONNECTIONS
+            );
+            return Err(Error::TooManyConnections);
+        }
+
+        self.add_listener(
+            conn.as_raw_fd(),
+            EpollListener::Connection {
+                key,
+                evset: conn.get_polled_evset(),
+            },
+        )
+        .and_then(|_| {
+            if conn.has_pending_rx() {
+                // We can safely ignore any error in adding a connection RX indication. Worst
+                // case scenario, the RX queue will get desynchronized, but we'll handle that
+                // the next time we need to yield an RX packet.
+                self.rxq.push(MuxerRx::ConnRx(key));
+            }
+            self.conn_map.insert(key, conn);
+
+            // METRICS.vsock.conns_added.inc();
+
+            Ok(())
+        })
+    }
+
+    /// Remove a connection from the active connection poll.
+    fn remove_connection(&mut self, key: ConnMapKey) {
+        if let Some(conn) = self.conn_map.remove(&key) {
+            self.remove_listener(conn.as_raw_fd());
+
+            // METRICS.vsock.conns_removed.inc();
+        }
+        self.free_local_port(key.local_port);
+    }
+
+    /// Schedule a connection for immediate termination.
+    /// I.e. as soon as we can also let our peer know we're dropping the connection, by sending
+    /// it an RST packet.
+    fn kill_connection(&mut self, key: ConnMapKey) {
+        let mut had_rx = false;
+
+        // METRICS.vsock.conns_killed.inc();
+
+        self.conn_map.entry(key).and_modify(|conn| {
+            had_rx = conn.has_pending_rx();
+            conn.kill();
+        });
+        // This connection will now have an RST packet to yield, so we need to add it to the RX
+        // queue.  However, there's no point in doing that if it was already in the queue.
+        if !had_rx {
+            // We can safely ignore any error in adding a connection RX indication. Worst case
+            // scenario, the RX queue will get desynchronized, but we'll handle that the next
+            // time we need to yield an RX packet.
+            self.rxq.push(MuxerRx::ConnRx(key));
+        }
+    }
+
+    /// Register a new epoll listener under the muxer's nested epoll FD.
+    fn add_listener(&mut self, fd: RawFd, listener: EpollListener) -> Result<()> {
+        let evset = match listener {
+            EpollListener::Connection { evset, .. } => evset,
+            EpollListener::LocalStream(_) => EventSet::IN,
+            EpollListener::HostSock => EventSet::IN,
+        };
+
+        self.epoll
+            .ctl(ControlOperation::Add, fd, EpollEvent::new(evset, fd as u64))
+            .and_then(|_| {
+                self.listener_map.insert(fd, listener);
+                Ok(())
+            })
+            .map_err(Error::EpollAdd)?;
+
+        Ok(())
+    }
+
+    /// Remove (and return) a previously registered epoll listener.
+    fn remove_listener(&mut self, fd: RawFd) -> Option<EpollListener> {
+        let maybe_listener = self.listener_map.remove(&fd);
+
+        if maybe_listener.is_some() {
+            self.epoll
+                .ctl(ControlOperation::Delete, fd, EpollEvent::default())
+                .unwrap_or_else(|err| {
+                    warn!(
+                        "vosck muxer: error removing epoll listener for fd {:?}: {:?}",
+                        fd, err
+                    );
+                });
+        }
+
+        maybe_listener
+    }
+
+    /// Allocate a host-side port to be assigned to a new host-initiated connection.
+    fn allocate_local_port(&mut self) -> u32 {
+        // TODO: this doesn't seem very space-efficient.
+        // Mybe rewrite this to limit port range and use a bitmap?
+        //
+
+        loop {
+            self.local_port_last = (self.local_port_last + 1) & !(1 << 31) | (1 << 30);
+            if self.local_port_set.insert(self.local_port_last) {
+                break;
+            }
+        }
+        self.local_port_last
+    }
+
+    /// Mark a previously used host-side port as free.
+    fn free_local_port(&mut self, port: u32) {
+        self.local_port_set.remove(&port);
+    }
+
+    /// Handle a new connection request comming from our peer (the guest vsock driver).
+    ///
+    /// This will attempt to connect to a host-side Unix socket, expected to be listening at
+    /// the file system path corresponing to the destination port. If successful, a new
+    /// connection object will be created and added to the connection pool. On failure, a new
+    /// RST packet will be scheduled for delivery to the guest.
+    fn handle_peer_request_pkt(&mut self, pkt: &VsockPacket) {
+        let port_path = format!("{}_{}", self.host_sock_path.display(), pkt.dst_port());
+
+        UnixStream::connect(port_path)
+            .and_then(|stream| stream.set_nonblocking(true).map(|_| stream))
+            .map_err(Error::UnixConnect)
+            .and_then(|stream| {
+                self.add_connection(
+                    ConnMapKey {
+                        local_port: pkt.dst_port(),
+                        peer_port: pkt.src_port(),
+                    },
+                    MuxerConnection::new_peer_init(
+                        stream,
+                        uapi::VSOCK_HOST_CID,
+                        self.cid,
+                        pkt.dst_port(),
+                        pkt.src_port(),
+                        pkt.buf_alloc(),
+                    ),
+                )
+            })
+            .unwrap_or_else(|_| self.enq_rst(pkt.dst_port(), pkt.src_port()));
+    }
+
+    /// Perform an action that might mutate a connection's state.
+    ///
+    /// This is used as shorthand for repetitive tasks that need to be performed after a
+    /// connection object mutates. E.g.
+    /// - update the connection's epoll listener;
+    /// - schedule the connection to be queried for RX data;
+    /// - kill the connection if an unrecoverable error occurs.
+    fn apply_conn_mutation<F>(&mut self, key: ConnMapKey, mut_fn: F)
+    where
+        F: FnOnce(&mut MuxerConnection),
+    {
+        if let Some(conn) = self.conn_map.get_mut(&key) {
+            let had_rx = conn.has_pending_rx();
+            let was_expiring = conn.will_expire();
+            let prev_state = conn.state();
+
+            mut_fn(conn);
+
+            // If this is a host-initiated connection that has just become established, we'll have
+            // to send an ack message to the host end.
+            if prev_state == ConnState::LocalInit && conn.state() == ConnState::Established {
+                let msg = format!("OK {}\n", key.local_port);
+                match conn.send_bytes_raw(msg.as_bytes()) {
+                    Ok(written) if written == msg.len() => (),
+                    Ok(_) => {
+                        // If we can't write a dozen bytes to a pristine connection something
+                        // must be really wrong. Killing it.
+                        conn.kill();
+                        warn!("vsock: unable to fully write connection ack msg.");
+                    }
+                    Err(err) => {
+                        conn.kill();
+                        warn!("vsock: unable to ack host connection: {:?}", err);
+                    }
+                };
+            }
+
+            // If the connection wasn't previously scheduled for RX, add it to our RX queue.
+            if !had_rx && conn.has_pending_rx() {
+                self.rxq.push(MuxerRx::ConnRx(key));
+            }
+
+            // If the connection wasn't previously scheduled for termination, add it to the
+            // kill queue.
+            if !was_expiring && conn.will_expire() {
+                // It's safe to unwrap here, since `conn.will_expire()` already guaranteed that
+                // an `conn.expiry` is available.
+                self.killq.push(key, conn.expiry().unwrap());
+            }
+
+            let fd = conn.as_raw_fd();
+            let new_evset = conn.get_polled_evset();
+            if new_evset.is_empty() {
+                // If the connection no longer needs epoll notifications, remove its listener
+                // from our list.
+                self.remove_listener(fd);
+                return;
+            }
+            if let Some(EpollListener::Connection { evset, .. }) = self.listener_map.get_mut(&fd) {
+                if *evset != new_evset {
+                    // If the set of events that the connection is interested in has changed,
+                    // we need to update its epoll listener.
+                    debug!(
+                        "vsock: updating listener for (lp={}, pp={}): old={:?}, new={:?}",
+                        key.local_port, key.peer_port, *evset, new_evset
+                    );
+
+                    *evset = new_evset;
+                    self.epoll
+                        .ctl(
+                            ControlOperation::Modify,
+                            fd,
+                            EpollEvent::new(new_evset, fd as u64),
+                        )
+                        .unwrap_or_else(|err| {
+                            // This really shouldn't happen, like, ever. However, "famous last
+                            // words" and all that, so let's just kill it with fire, and walk away.
+                            self.kill_connection(key);
+                            error!(
+                                "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
+                                key.local_port, key.peer_port, err
+                            );
+
+                            // METRICS.vsock.muxer_event_fails.inc();
+                        });
+                }
+            } else {
+                // The connection had previously asked to be removed from the listener map (by
+                // returning an empty event set via `get_polled_fd()`), but now wants back in.
+                self.add_listener(
+                    fd,
+                    EpollListener::Connection {
+                        key,
+                        evset: new_evset,
+                    },
+                )
+                .unwrap_or_else(|err| {
+                    self.kill_connection(key);
+                    error!(
+                        "vsock: error updating epoll listener for (lp={}, pp={}): {:?}",
+                        key.local_port, key.peer_port, err
+                    );
+
+                    // METRICS.vsock.muxer_event_fails.inc();
+                });
+            }
+        }
+    }
+
+    /// Check if any connections have timed out, and if so, schedule them for immediate
+    /// termination.
+    fn sweep_killq(&mut self) {
+        while let Some(key) = self.killq.pop() {
+            // Connections don't get removed from the kill queue when their kill timer is
+            // disarmed, since that would be a costly operation. This means we must check if
+            // the connection has indeed expired, prior to killing it.
+            let mut kill = false;
+            self.conn_map
+                .entry(key)
+                .and_modify(|conn| kill = conn.has_expired());
+            if kill {
+                self.kill_connection(key);
+            }
+        }
+
+        if self.killq.is_empty() && !self.killq.is_synced() {
+            self.killq = MuxerKillQ::from_conn_map(&self.conn_map);
+
+            // METRICS.vsock.killq_resync.inc();
+
+            // If we've just re-created the kill queue, we can sweep it again; maybe there's
+            // more to kill.
+            self.sweep_killq();
+        }
+    }
+
+    /// Enqueue an RST packet into `self.rxq`.
+    ///
+    /// Enqueue errors aren't propagated up the call chain, since there is nothing we can do to
+    /// handle them. We do, however, log a warning, since not being able to enqueue an RST
+    /// packet means we have to drop it, which is not normal operation.
+    fn enq_rst(&mut self, local_port: u32, peer_port: u32) {
+        let pushed = self.rxq.push(MuxerRx::RstPkt {
+            local_port,
+            peer_port,
+        });
+        if !pushed {
+            warn!(
+                "vsock: muxer.rxq full; dropping RST packet for lp={}, pp={}",
+                local_port, peer_port
+            );
+        }
+    }
+}

--- a/src/devices/src/virtio/vsock/unix/muxer_killq.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer_killq.rs
@@ -1,0 +1,129 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `MuxerKillQ` implements a helper object that `VsockMuxer` can use for scheduling forced
+/// connection termination. I.e. after one peer issues a clean shutdown request
+/// (VSOCK_OP_SHUTDOWN), the concerned connection is queued for termination (VSOCK_OP_RST) in
+/// the near future (herein implemented via an expiring timer).
+///
+/// Whenever the muxer needs to schedule a connection for termination, it pushes it (or rather
+/// an identifier - the connection key) to this queue. A subsequent pop() operation will
+/// succeed if and only if the first connection in the queue is ready to be terminated (i.e.
+/// its kill timer expired).
+///
+/// Without using this queue, the muxer would have to walk its entire connection pool
+/// (hashmap), whenever it needs to check for expired kill timers. With this queue, both
+/// scheduling and termination are performed in constant time. However, since we don't want to
+/// waste space on a kill queue that's as big as the connection hashmap itself, it is possible
+/// that this queue may become full at times.  We call this kill queue "synchronized" if we are
+/// certain that all connections that are awaiting termination are present in the queue. This
+/// means a simple constant-time pop() operation is enough to check whether any connections
+/// need to be terminated.  When the kill queue becomes full, though, pushing fails, so
+/// connections that should be terminated are left out. The queue is not synchronized anymore.
+/// When that happens, the muxer will first drain the queue, and then replace it with a new
+/// queue, created by walking the connection pool, looking for connections that will be
+/// expiring in the future.
+use std::collections::{HashMap, VecDeque};
+use std::time::Instant;
+
+use super::defs;
+use super::muxer::ConnMapKey;
+use super::MuxerConnection;
+
+/// A kill queue item, holding the connection key and the scheduled time for termination.
+#[derive(Clone, Copy)]
+struct MuxerKillQItem {
+    key: ConnMapKey,
+    kill_time: Instant,
+}
+
+/// The connection kill queue: a FIFO structure, storing the connections that are scheduled for
+/// termination.
+pub struct MuxerKillQ {
+    /// The kill queue contents.
+    q: VecDeque<MuxerKillQItem>,
+
+    /// The kill queue sync status:
+    /// - when true, all connections that are awaiting termination are guaranteed to be in this
+    ///   queue;
+    /// - when false, some connections may have been left out.
+    synced: bool,
+}
+
+impl MuxerKillQ {
+    const SIZE: usize = defs::MUXER_KILLQ_SIZE;
+
+    /// Trivial kill queue constructor.
+    pub fn new() -> Self {
+        Self {
+            q: VecDeque::with_capacity(Self::SIZE),
+            synced: true,
+        }
+    }
+
+    /// Create a kill queue by walking the connection pool, looking for connections that are
+    /// set to expire at some point in the future.
+    /// Note: if more than `Self::SIZE` connections are found, the queue will be created in an
+    ///       out-of-sync state, and will be discarded after it is emptied.
+    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+        let mut q_buf: Vec<MuxerKillQItem> = Vec::with_capacity(Self::SIZE);
+        let mut synced = true;
+        for (key, conn) in conn_map.iter() {
+            if !conn.will_expire() {
+                continue;
+            }
+            if q_buf.len() >= Self::SIZE {
+                synced = false;
+                break;
+            }
+            q_buf.push(MuxerKillQItem {
+                key: *key,
+                kill_time: conn.expiry().unwrap(),
+            });
+        }
+        q_buf.sort_unstable_by_key(|it| it.kill_time);
+        Self {
+            q: q_buf.into(),
+            synced,
+        }
+    }
+
+    /// Push a connection key to the queue, scheduling it for termination at
+    /// `CONN_SHUTDOWN_TIMEOUT_MS` from now (the push time).
+    pub fn push(&mut self, key: ConnMapKey, kill_time: Instant) {
+        if !self.is_synced() || self.is_full() {
+            self.synced = false;
+            return;
+        }
+        self.q.push_back(MuxerKillQItem { key, kill_time });
+    }
+
+    /// Attempt to pop an expired connection from the kill queue.
+    ///
+    /// This will succeed and return a connection key, only if the connection at the front of
+    /// the queue has expired. Otherwise, `None` is returned.
+    pub fn pop(&mut self) -> Option<ConnMapKey> {
+        if let Some(item) = self.q.front() {
+            if Instant::now() > item.kill_time {
+                return Some(self.q.pop_front().unwrap().key);
+            }
+        }
+        None
+    }
+
+    /// Check if the kill queue is synchronized with the connection pool.
+    pub fn is_synced(&self) -> bool {
+        self.synced
+    }
+
+    /// Check if the kill queue is empty, obviously.
+    pub fn is_empty(&self) -> bool {
+        self.q.len() == 0
+    }
+
+    /// Check if the kill queue is full.
+    pub fn is_full(&self) -> bool {
+        self.q.len() == Self::SIZE
+    }
+}

--- a/src/devices/src/virtio/vsock/unix/muxer_rxq.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer_rxq.rs
@@ -1,0 +1,134 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// `MuxerRxQ` implements a helper object that `VsockMuxer` can use for queuing RX (host -> guest)
+/// packets (or rather instructions on how to build said packets).
+///
+/// Under ideal operation, every connection, that has pending RX data, will be present in the muxer
+/// RX queue. However, since the RX queue is smaller than the connection pool, it may, under some
+/// conditions, become full, meaning that it can no longer account for all the connections that can
+/// yield RX data.  When that happens, we say that it is no longer "synchronized" (i.e. with the
+/// connection pool).  A desynchronized RX queue still holds valid data, and the muxer will
+/// continue to pop packets from it. However, when a desynchronized queue is drained, additional
+/// data may still be available, so the muxer will have to perform a more costly walk of the entire
+/// connection pool to find it.  This walk is performed here, as part of building an RX queue from
+/// the connection pool. When an out-of-sync is drained, the muxer will discard it, and attempt to
+/// rebuild a synced one.
+use std::collections::{HashMap, VecDeque};
+
+use super::super::VsockChannel;
+use super::defs;
+use super::muxer::{ConnMapKey, MuxerRx};
+use super::MuxerConnection;
+
+/// The muxer RX queue.
+pub struct MuxerRxQ {
+    /// The RX queue data.
+    q: VecDeque<MuxerRx>,
+    /// The RX queue sync status.
+    synced: bool,
+}
+
+impl MuxerRxQ {
+    const SIZE: usize = defs::MUXER_RXQ_SIZE;
+
+    /// Trivial RX queue constructor.
+    pub fn new() -> Self {
+        Self {
+            q: VecDeque::with_capacity(Self::SIZE),
+            synced: true,
+        }
+    }
+
+    /// Attempt to build an RX queue, that is synchronized to the connection pool.
+    /// Note: the resulting queue may still be desynchronized, if there are too many connections
+    ///       that have pending RX data. In that case, the muxer will first drain this queue, and
+    ///       then try again to build a synchronized one.
+    pub fn from_conn_map(conn_map: &HashMap<ConnMapKey, MuxerConnection>) -> Self {
+        let mut q = VecDeque::new();
+        let mut synced = true;
+
+        for (key, conn) in conn_map.iter() {
+            if !conn.has_pending_rx() {
+                continue;
+            }
+            if q.len() >= Self::SIZE {
+                synced = false;
+                break;
+            }
+            q.push_back(MuxerRx::ConnRx(*key));
+        }
+        Self { q, synced }
+    }
+
+    /// Push a new RX item to the queue.
+    ///
+    /// A push will fail when:
+    /// - trying to push a connection key onto an out-of-sync, or full queue; or
+    /// - trying to push an RST onto a queue already full of RSTs.
+    /// RSTs take precedence over connections, because connections can always be queried for
+    /// pending RX data later. Aside from this queue, there is no other storage for RSTs, so
+    /// failing to push one means that we have to drop the packet.
+    ///
+    /// Returns:
+    /// - `true` if the new item has been successfully queued; or
+    /// - `false` if there was no room left in the queue.
+    pub fn push(&mut self, rx: MuxerRx) -> bool {
+        // Pushing to a non-full, synchronized queue will always succeed.
+        if self.is_synced() && !self.is_full() {
+            self.q.push_back(rx);
+            return true;
+        }
+
+        match rx {
+            MuxerRx::RstPkt { .. } => {
+                // If we just failed to push an RST packet, we'll look through the queue, trying to
+                // find a connection key that we could evict. This way, the queue does lose sync,
+                // but we don't drop any packets.
+                for qi in self.q.iter_mut().rev() {
+                    if let MuxerRx::ConnRx(_) = qi {
+                        *qi = rx;
+                        self.synced = false;
+                        return true;
+                    }
+                }
+            }
+            MuxerRx::ConnRx(_) => {
+                self.synced = false;
+            }
+        };
+
+        false
+    }
+
+    /// Peek into the front of the queue.
+    pub fn peek(&self) -> Option<MuxerRx> {
+        self.q.front().copied()
+    }
+
+    /// Pop an RX item from the front of the queue.
+    pub fn pop(&mut self) -> Option<MuxerRx> {
+        self.q.pop_front()
+    }
+
+    /// Check if the RX queue is synchronized with the connection pool.
+    pub fn is_synced(&self) -> bool {
+        self.synced
+    }
+
+    /// Get the total number of items in the queue.
+    pub fn len(&self) -> usize {
+        self.q.len()
+    }
+
+    /// Check if the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Check if the queue is full.
+    pub fn is_full(&self) -> bool {
+        self.len() == Self::SIZE
+    }
+}

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2.76"
 kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.5.0"
 vm-memory = { version = "0.4.0" }
-vmm-sys-util = "0.6.1"
+vmm-sys-util = "0.7.0"
 
 # vm-device is not yet published on crates.io.
 # To make sure that breaking changes to vm-device are not breaking the

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -13,7 +13,7 @@ libc = "0.2.76"
 linux-loader = { version = "0.2.0", features = ["bzimage", "elf"] }
 vm-memory = { version = "0.4.0", features = ["backend-mmap"] }
 vm-superio = "0.1.1"
-vmm-sys-util = "0.6.1"
+vmm-sys-util = "0.7.0"
 
 # vm-device is not yet published on crates.io.
 # To make sure that breaking changes to vm-device are not breaking the

--- a/src/vmm/src/config.rs
+++ b/src/vmm/src/config.rs
@@ -31,7 +31,7 @@ impl fmt::Display for ConversionError {
             ParseMemory(ref s) => write!(f, "Invalid input for memory: {}", s),
             ParseVcpus(ref s) => write!(f, "Invalid input for vCPUs: {}", s),
             ParseNetwork(ref s) => write!(f, "Invalid input for network: {}", s),
-            ParseBlock(ref s) => write!(f, "Invalid input for network: {}", s),
+            ParseBlock(ref s) => write!(f, "Invalid input for block: {}", s),
         }
     }
 }


### PR DESCRIPTION
This PR adds support for vsock devices, based on the backend and packet parser implementation currently available in Firecracker (some more details about the Firecracker Unix Domain Socket vsock backend are available [here](https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md)). The code is written and brought over on top of #49. 

One way to verify the vsock device operation is to follow the next steps. First, build the vsock helper program from [here](https://github.com/firecracker-microvm/firecracker/blob/master/tests/host_tools/vsock_helper.c) (ideally as a static binary) and copy the binary to the guest filesystem image. After the guest boots with a vsock device added (i.e. by appending something like ` --vsock cid=5,uds_path=/tmp/vsock_uds0` to the vmm command line), start the listener server within the guest using `./vsock_helper echosrv 5252` (5252 is an arbitrary port number). Then, on the host, we can use something like the following script to verify that can send some data over the UDS vsock backend, and get a reply:

```python
import re
from socket import socket, AF_UNIX, SOCK_STREAM

uds_path = '/tmp/vsock_uds0'
port = 5252

sock = socket(AF_UNIX, SOCK_STREAM)
sock.connect(uds_path)

buf = bytearray("CONNECT {}\n".format(port).encode("utf-8"))
assert sock.send(buf) == len(buf)

ack_buf = sock.recv(32)
assert re.match("^OK [0-9]+\n$", ack_buf.decode('utf-8')) is not None

msg = "vsock is working"
msg_buf = bytes(msg, 'utf-8')

sent = sock.send(msg_buf)
assert sent == len(msg_buf)

recv_buf = sock.recv(sent)
assert len(recv_buf) == len(msg_buf)
assert recv_buf == msg_buf

print(recv_buf.decode('utf-8'))
```

We're going to bring over parts of the vsock test infrastructure as well after advancing the discussion around dirty page tracking in `vm-memory` and seeing how the ongoing `vm-virtio` discussions conclude. The former is important because we want to start using `VolatileSlice`s for the `VsockPacket` abstractions, while the latter influence the boiler plate code we have to adapt as part of the testing infrastructure.