### PR TITLE
Issue 55

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {  
-  "coverage_score": 79.7,
+  "coverage_score": 79.8,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/",
   "crate_features": ""
 }

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -157,7 +157,7 @@ mod tests {
         ])
         .is_err());
 
-        // Invalid memory config: missing value for `size_mib`.
+        // Memory config: missing value for `size_mib`, use the default
         assert!(CLI::launch(vec![
             "foobar",
             "--memory",
@@ -167,7 +167,7 @@ mod tests {
             "--kernel",
             "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
         ])
-        .is_err());
+        .is_ok());
 
         // Invalid memory config: unexpected parameter `foobar`.
         assert!(CLI::launch(vec![
@@ -194,7 +194,7 @@ mod tests {
         ])
         .is_err());
 
-        // Invalid kernel config: missing value for `himem_start`.
+        // Kernel config: missing value for `himem_start`, use default
         assert!(CLI::launch(vec![
             "foobar",
             "--memory",
@@ -204,7 +204,7 @@ mod tests {
             "--kernel",
             "path=/foo/bar,cmdline=\"foo=bar\",himem_start=",
         ])
-        .is_err());
+        .is_ok());
 
         // Invalid kernel config: unexpected parameter `foobar`.
         assert!(CLI::launch(vec![
@@ -230,7 +230,7 @@ mod tests {
         ])
         .is_err());
 
-        // Invalid vCPU config: missing value for `num_vcpus`.
+        // vCPU config: missing value for `num_vcpus`, use default
         assert!(CLI::launch(vec![
             "foobar",
             "--memory",
@@ -240,7 +240,7 @@ mod tests {
             "--kernel",
             "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
         ])
-        .is_err());
+        .is_ok());
 
         // Invalid vCPU config: unexpected parameter `foobar`.
         assert!(CLI::launch(vec![

--- a/src/vmm/src/config/arg_parser.rs
+++ b/src/vmm/src/config/arg_parser.rs
@@ -1,0 +1,129 @@
+use crate::config::arg_parser::CfgArgParseError::UnknownArg;
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Formatter;
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq)]
+pub(super) enum CfgArgParseError {
+    /// Parsing failed, param and error.
+    ParsingFailed(&'static str, String),
+    UnknownArg(String),
+}
+
+impl fmt::Display for CfgArgParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ParsingFailed(param, err) => {
+                write!(f, "Param '{}', parsing failed: {}", param, err)
+            }
+            Self::UnknownArg(err) => write!(f, "Unknown arguments found: '{}'", err),
+        }
+    }
+}
+
+pub(super) struct CfgArgParser {
+    args: HashMap<String, String>,
+}
+
+impl CfgArgParser {
+    pub(super) fn new(input: String) -> Self {
+        let args = input
+            .split(',')
+            .filter(|tok| !tok.is_empty())
+            .map(|tok| {
+                let mut iter = tok.splitn(2, '=');
+                let param_name = iter.next().unwrap();
+                let value = iter.next().unwrap_or("").to_string();
+                (param_name.to_lowercase(), value)
+            })
+            .collect();
+        Self { args }
+    }
+
+    /// Retrieves the value of `param`, consuming it from `Self`.
+    pub(super) fn value_of<T: FromStr>(
+        &mut self,
+        param_name: &'static str,
+    ) -> Result<Option<T>, CfgArgParseError>
+    where
+        <T as FromStr>::Err: std::fmt::Display,
+    {
+        match self.args.remove(param_name) {
+            Some(value) if !value.is_empty() => value
+                .parse::<T>()
+                .map_err(|err| CfgArgParseError::ParsingFailed(param_name, err.to_string()))
+                .map(Some),
+            _ => Ok(None),
+        }
+    }
+
+    /// Checks if all params were consumed.
+    pub(super) fn all_consumed(&self) -> Result<(), CfgArgParseError> {
+        if self.args.is_empty() {
+            Ok(())
+        } else {
+            Err(UnknownArg(self.to_string()))
+        }
+    }
+}
+
+impl fmt::Display for CfgArgParser {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.args
+                .keys()
+                .map(|val| val.as_str())
+                .collect::<Vec<&str>>()
+                .join(", ")
+        )
+    }
+}
+#[cfg(test)]
+mod tests {
+    use crate::config::arg_parser::{CfgArgParseError, CfgArgParser};
+    use std::num::NonZeroU8;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_cfg_arg_parse() -> Result<(), CfgArgParseError> {
+        let input_params = "path=/path,string=HelloWorld,int=123,u8=1".to_string();
+        let mut arg_parser = CfgArgParser::new(input_params);
+
+        // No parameter was consumed yet
+        assert!(arg_parser.all_consumed().is_err());
+
+        assert_eq!(
+            arg_parser.value_of::<PathBuf>("path")?.unwrap(),
+            PathBuf::from("/path")
+        );
+        assert_eq!(
+            arg_parser.value_of::<String>("string")?.unwrap(),
+            "HelloWorld".to_string()
+        );
+        assert_eq!(
+            arg_parser.value_of::<NonZeroU8>("u8")?.unwrap(),
+            NonZeroU8::new(1).unwrap()
+        );
+        assert_eq!(arg_parser.value_of::<u64>("int")?.unwrap(), 123);
+
+        // Params now is empty, use the Default instead.
+        let default = 12;
+        assert_eq!(arg_parser.value_of("int")?.unwrap_or(default), default);
+
+        // Params is empty and no Default provided:
+        assert!(arg_parser.value_of::<u64>("int")?.is_none());
+
+        // All params were consumed:
+        assert!(arg_parser.all_consumed().is_ok());
+
+        let input_params = "path=".to_string();
+        assert!(CfgArgParser::new(input_params)
+            .value_of::<String>("path")?
+            .is_none());
+
+        Ok(())
+    }
+}

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -36,21 +36,19 @@ use vm_device::device_manager::IoManager;
 use vm_device::resources::Resource;
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
 use vm_superio::Serial;
-use vm_vcpu::vcpu::{cpuid::filter_cpuid, VcpuState};
-use vm_vcpu::vm::{self, KvmVm, VmState};
 use vmm_sys_util::{eventfd::EventFd, terminal::Terminal};
 
+use boot::build_bootparams;
+pub use config::*;
 use devices::virtio::block::{self, BlockArgs};
 use devices::virtio::{CommonArgs, MmioConfig};
+use serial::SerialWrapper;
+use vm_vcpu::vcpu::{cpuid::filter_cpuid, VcpuState};
+use vm_vcpu::vm::{self, KvmVm, VmState};
 
 mod boot;
-use boot::build_bootparams;
-
 mod config;
-pub use config::*;
-
 mod serial;
-use serial::SerialWrapper;
 
 /// First address past 32 bits is where the MMIO gap ends.
 pub(crate) const MMIO_GAP_END: u64 = 1 << 32;
@@ -435,8 +433,6 @@ impl VMM {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::io::ErrorKind;
     use std::mem;
     use std::path::PathBuf;
@@ -446,6 +442,8 @@ mod tests {
     use vm_memory::bytes::{ByteValued, Bytes};
     use vm_memory::{Address, GuestAddress, GuestMemory};
     use vmm_sys_util::{tempdir::TempDir, tempfile::TempFile};
+
+    use super::*;
 
     const MEM_SIZE_MIB: u32 = 1024;
     const NUM_VCPUS: u8 = 1;


### PR DESCRIPTION
Fixes #55 

This is still a draft PR. While most of the code is there, I would like to add some more testing for the code I've added.
    
This refactoring aims to deduplicate the parsing effort among the config's
structs and ease the addition of new parameters and structs.

The ArgParsing trait is used to offer a parse method, which needs to be
implemented for each type one wants to parse. If there are special parsing
cases (e.g. u8 > 0) it's also possible to introduce this by creating a new
wrapper struct and implement the ArgParsing accordingly.

For avoiding code duplication, `argparsing` macro is introduced to avoid
copy pasting identical implementation for numberic types.

Finally, the newly introduced ParsingError enum allows for more precise
error reporting, and more on point error reporting (please check the updated
tests cases with example of possible errors).
