### PR TITLE
Implementation of Builder pattern for Config

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
-{  
-  "coverage_score": 79.8,
+{
+  "coverage_score": 80.2,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/",
   "crate_features": ""
 }

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -70,7 +70,7 @@ impl CLI {
             .memory_config(matches.value_of("memory"))
             .kernel_config(matches.value_of("kernel"))
             .vcpu_config(matches.value_of("vcpu"))
-            .network_config(matches.value_of("net"))
+            .net_config(matches.value_of("net"))
             .block_config(matches.value_of("block"))
             .build()
             .map_err(|e| format!("{:?}", e))?)
@@ -233,7 +233,7 @@ mod tests {
                 memory_config: MemoryConfig { size_mib: 128 },
                 vcpu_config: VcpuConfig { num: 1 },
                 block_config: None,
-                network_config: None,
+                net_config: None,
             }
         );
 
@@ -249,7 +249,7 @@ mod tests {
                 memory_config: MemoryConfig { size_mib: 256 },
                 vcpu_config: VcpuConfig { num: 1 },
                 block_config: None,
-                network_config: None,
+                net_config: None,
             }
         );
     }

--- a/src/vmm/src/config/arg_parser.rs
+++ b/src/vmm/src/config/arg_parser.rs
@@ -28,7 +28,7 @@ pub(super) struct CfgArgParser {
 }
 
 impl CfgArgParser {
-    pub(super) fn new(input: String) -> Self {
+    pub(super) fn new(input: &str) -> Self {
         let args = input
             .split(',')
             .filter(|tok| !tok.is_empty())
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_cfg_arg_parse() -> Result<(), CfgArgParseError> {
-        let input_params = "path=/path,string=HelloWorld,int=123,u8=1".to_string();
+        let input_params = "path=/path,string=HelloWorld,int=123,u8=1";
         let mut arg_parser = CfgArgParser::new(input_params);
 
         // No parameter was consumed yet
@@ -120,7 +120,7 @@ mod tests {
         // All params were consumed:
         assert!(arg_parser.all_consumed().is_ok());
 
-        let input_params = "path=".to_string();
+        let input_params = "path=";
         assert!(CfgArgParser::new(input_params)
             .value_of::<String>("path")?
             .is_none());

--- a/src/vmm/src/config/builder.rs
+++ b/src/vmm/src/config/builder.rs
@@ -141,14 +141,14 @@ impl Builder {
     /// You can see example of how to use this function in [`Example` section from
     /// `build`](#method.build)
     ///
-    pub fn network_config<T>(self, network: Option<T>) -> Self
+    pub fn net_config<T>(self, net: Option<T>) -> Self
     where
         NetConfig: TryFrom<T>,
         <NetConfig as TryFrom<T>>::Error: Into<ConversionError>,
     {
-        match network {
+        match net {
             Some(n) => self.and_then(|mut config| {
-                config.network_config = Some(TryFrom::try_from(n).map_err(Into::into)?);
+                config.net_config = Some(TryFrom::try_from(n).map_err(Into::into)?);
                 Ok(config)
             }),
             None => self,
@@ -274,22 +274,22 @@ mod tests {
     #[test]
     fn test_builder_net_config_none_default() {
         let vmm_config = Builder::default()
-            .network_config(None as Option<&str>)
+            .net_config(None as Option<&str>)
             .kernel_config(Some("path=bzImage"))
             .build();
         assert!(vmm_config.is_ok());
-        assert!(vmm_config.unwrap().network_config.is_none());
+        assert!(vmm_config.unwrap().net_config.is_none());
     }
 
     #[test]
     fn test_builder_net_config_success() {
         let vmm_config = Builder::default()
-            .network_config(Some("tap=tap0"))
+            .net_config(Some("tap=tap0"))
             .kernel_config(Some("path=bzImage"))
             .build();
         assert!(vmm_config.is_ok());
         assert_eq!(
-            vmm_config.unwrap().network_config,
+            vmm_config.unwrap().net_config,
             Some(NetConfig {
                 tap_name: "tap0".to_string()
             })

--- a/src/vmm/src/config/builder.rs
+++ b/src/vmm/src/config/builder.rs
@@ -1,0 +1,125 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+//! Config builder
+use std::convert::TryFrom;
+
+use super::{
+    BlockConfig, ConversionError, KernelConfig, MemoryConfig, NetConfig, VMMConfig, VcpuConfig,
+};
+
+/// Builder structure for VMMConfig
+#[derive(Debug)]
+pub struct Builder {
+    inner: Result<VMMConfig, ConversionError>,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Builder {
+    pub fn new() -> Self {
+        Builder {
+            inner: Ok(VMMConfig::default()),
+        }
+    }
+
+    pub fn build(&self) -> Result<VMMConfig, ConversionError> {
+        // Check if there are any errors
+        match &self.inner {
+            Ok(vc) => {
+                // Empty kernel image path.
+                if vc.kernel_config.path.to_str().unwrap().is_empty() {
+                    return Err(ConversionError::ParseKernel(
+                        "Kernel Image Path is Empty.".to_string(),
+                    ));
+                }
+            }
+            Err(_) => {}
+        }
+
+        self.inner.clone()
+    }
+
+    pub fn memory_config<T>(self, memory: Option<T>) -> Self
+    where
+        MemoryConfig: TryFrom<T>,
+        <MemoryConfig as TryFrom<T>>::Error: Into<ConversionError>,
+    {
+        match memory {
+            Some(m) => self.and_then(|mut config| {
+                config.memory_config = TryFrom::try_from(m).map_err(Into::into)?;
+                Ok(config)
+            }),
+            None => self,
+        }
+    }
+
+    pub fn vcpu_config<T>(self, vcpu: Option<T>) -> Self
+    where
+        VcpuConfig: TryFrom<T>,
+        <VcpuConfig as TryFrom<T>>::Error: Into<ConversionError>,
+    {
+        match vcpu {
+            Some(v) => self.and_then(|mut config| {
+                config.vcpu_config = TryFrom::try_from(v).map_err(Into::into)?;
+                Ok(config)
+            }),
+            None => self,
+        }
+    }
+
+    pub fn kernel_config<T>(self, kernel: Option<T>) -> Self
+    where
+        KernelConfig: TryFrom<T>,
+        <KernelConfig as TryFrom<T>>::Error: Into<ConversionError>,
+    {
+        match kernel {
+            Some(k) => self.and_then(|mut config| {
+                config.kernel_config = TryFrom::try_from(k).map_err(Into::into)?;
+                Ok(config)
+            }),
+            None => self,
+        }
+    }
+
+    pub fn network_config<T>(self, network: Option<T>) -> Self
+    where
+        NetConfig: TryFrom<T>,
+        <NetConfig as TryFrom<T>>::Error: Into<ConversionError>,
+    {
+        match network {
+            Some(n) => self.and_then(|mut config| {
+                config.network_config = Some(TryFrom::try_from(n).map_err(Into::into)?);
+                Ok(config)
+            }),
+            None => self,
+        }
+    }
+
+    pub fn block_config<T>(self, block: Option<T>) -> Self
+    where
+        BlockConfig: TryFrom<T>,
+        <BlockConfig as TryFrom<T>>::Error: Into<ConversionError>,
+    {
+        match block {
+            Some(b) => self.and_then(|mut config| {
+                config.block_config = Some(TryFrom::try_from(b).map_err(Into::into)?);
+                Ok(config)
+            }),
+            None => self,
+        }
+    }
+
+    fn and_then<F>(self, func: F) -> Self
+    where
+        F: FnOnce(VMMConfig) -> Result<VMMConfig, ConversionError>,
+    {
+        Builder {
+            inner: self.inner.and_then(func),
+        }
+    }
+}

--- a/src/vmm/src/config/mod.rs
+++ b/src/vmm/src/config/mod.rs
@@ -11,10 +11,14 @@ use arg_parser::CfgArgParser;
 
 use super::{DEFAULT_HIGH_RAM_START, DEFAULT_KERNEL_CMDLINE};
 
+use builder::Builder;
+
 mod arg_parser;
 
+mod builder;
+
 /// Errors encountered converting the `*Config` objects.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ConversionError {
     /// Failed to parse the string representation for the kernel.
     ParseKernel(String),
@@ -46,6 +50,13 @@ impl ConversionError {
     }
 }
 
+impl VMMConfig {
+    /// Builds a builder
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+}
+
 impl fmt::Display for ConversionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ConversionError::*;
@@ -60,10 +71,16 @@ impl fmt::Display for ConversionError {
 }
 
 /// Guest memory configurations.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct MemoryConfig {
     /// Guest memory size in MiB.
     pub size_mib: u32,
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        MemoryConfig { size_mib: 256u32 }
+    }
 }
 
 impl TryFrom<&str> for MemoryConfig {
@@ -91,6 +108,12 @@ pub struct VcpuConfig {
     pub num: u8,
 }
 
+impl Default for VcpuConfig {
+    fn default() -> Self {
+        VcpuConfig { num: 1u8 }
+    }
+}
+
 impl TryFrom<&str> for VcpuConfig {
     type Error = ConversionError;
 
@@ -109,7 +132,7 @@ impl TryFrom<&str> for VcpuConfig {
 }
 
 /// Guest kernel configurations.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct KernelConfig {
     /// Kernel command line.
     pub cmdline: String,
@@ -117,6 +140,16 @@ pub struct KernelConfig {
     pub path: PathBuf,
     /// Start address for high memory.
     pub himem_start: u64,
+}
+
+impl Default for KernelConfig {
+    fn default() -> Self {
+        KernelConfig {
+            cmdline: String::from(DEFAULT_KERNEL_CMDLINE),
+            path: PathBuf::from(""), // FIXME: make it a const.
+            himem_start: DEFAULT_HIGH_RAM_START,
+        }
+    }
 }
 
 impl TryFrom<&str> for KernelConfig {
@@ -153,7 +186,7 @@ impl TryFrom<&str> for KernelConfig {
     }
 }
 /// Network device configuration.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct NetConfig {
     /// Name of tap device.
     pub tap_name: String,
@@ -179,7 +212,7 @@ impl TryFrom<&str> for NetConfig {
 }
 
 /// Block device configuration
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BlockConfig {
     /// Path to the block device backend.
     pub path: PathBuf,

--- a/src/vmm/src/config/mod.rs
+++ b/src/vmm/src/config/mod.rs
@@ -27,7 +27,7 @@ pub enum ConversionError {
     /// Failed to parse the string representation for the vCPUs.
     ParseVcpus(String),
     /// Failed to parse the string representation for the network.
-    ParseNetwork(String),
+    ParseNet(String),
     /// Failed to parse the string representation for the block.
     ParseBlock(String),
 }
@@ -45,8 +45,8 @@ impl ConversionError {
     fn new_block<T: fmt::Display>(err: T) -> Self {
         Self::ParseBlock(err.to_string())
     }
-    fn new_network<T: fmt::Display>(err: T) -> Self {
-        Self::ParseNetwork(err.to_string())
+    fn new_net<T: fmt::Display>(err: T) -> Self {
+        Self::ParseNet(err.to_string())
     }
 }
 
@@ -64,8 +64,8 @@ impl fmt::Display for ConversionError {
             ParseKernel(ref s) => write!(f, "Invalid input for kernel: {}", s),
             ParseMemory(ref s) => write!(f, "Invalid input for memory: {}", s),
             ParseVcpus(ref s) => write!(f, "Invalid input for vCPUs: {}", s),
-            ParseNetwork(ref s) => write!(f, "Invalid input for network: {}", s),
-            ParseBlock(ref s) => write!(f, "Invalid input for network: {}", s),
+            ParseNet(ref s) => write!(f, "Invalid input for network: {}", s),
+            ParseBlock(ref s) => write!(f, "Invalid input for block: {}", s),
         }
     }
 }
@@ -201,12 +201,12 @@ impl TryFrom<&str> for NetConfig {
 
         let tap_name = arg_parser
             .value_of("tap")
-            .map_err(ConversionError::new_network)?
-            .ok_or_else(|| ConversionError::new_network("Missing required argument: tap"))?;
+            .map_err(ConversionError::new_net)?
+            .ok_or_else(|| ConversionError::new_net("Missing required argument: tap"))?;
 
         arg_parser
             .all_consumed()
-            .map_err(ConversionError::new_network)?;
+            .map_err(ConversionError::new_net)?;
         Ok(NetConfig { tap_name })
     }
 }
@@ -247,7 +247,7 @@ pub struct VMMConfig {
     /// Guest kernel configuration.
     pub kernel_config: KernelConfig,
     /// Network device configuration.
-    pub network_config: Option<NetConfig>,
+    pub net_config: Option<NetConfig>,
     /// Block device configuration.
     pub block_config: Option<BlockConfig>,
 }
@@ -313,28 +313,28 @@ mod tests {
     }
 
     #[test]
-    fn test_network_config() {
-        let network_str = "tap=vmtap";
-        let network_cfg = NetConfig::try_from(network_str).unwrap();
+    fn test_net_config() {
+        let net_str = "tap=vmtap";
+        let net_cfg = NetConfig::try_from(net_str).unwrap();
         let expected_cfg = NetConfig {
             tap_name: "vmtap".to_string(),
         };
-        assert_eq!(network_cfg, expected_cfg);
+        assert_eq!(net_cfg, expected_cfg);
 
         // Test case: empty string error.
         assert!(NetConfig::try_from("").is_err());
 
         // Test case: empty tap name error.
-        let network_str = "tap=";
-        assert!(NetConfig::try_from(network_str).is_err());
+        let net_str = "tap=";
+        assert!(NetConfig::try_from(net_str).is_err());
 
         // Test case: invalid string.
-        let network_str = "blah=blah";
-        assert!(NetConfig::try_from(network_str).is_err());
+        let net_str = "blah=blah";
+        assert!(NetConfig::try_from(net_str).is_err());
 
         // Test case: unused parameters
-        let network_str = "tap=something,blah=blah";
-        assert!(NetConfig::try_from(network_str).is_err());
+        let net_str = "tap=something,blah=blah";
+        assert!(NetConfig::try_from(net_str).is_err());
     }
 
     #[test]

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -48,6 +48,7 @@ use vm_vcpu::vm::{self, KvmVm, VmState};
 
 mod boot;
 mod config;
+
 mod serial;
 
 /// First address past 32 bits is where the MMIO gap ends.
@@ -184,7 +185,7 @@ impl TryFrom<VMMConfig> for VMM {
         }
 
         if !cmdline.as_str().is_empty() {
-            vmm.kernel_cfg.cmdline.push_str(" ");
+            vmm.kernel_cfg.cmdline.push(' ');
             vmm.kernel_cfg.cmdline.push_str(cmdline.as_str());
         }
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -469,7 +469,7 @@ mod tests {
             },
             vcpu_config: VcpuConfig { num: NUM_VCPUS },
             block_config: None,
-            network_config: None,
+            net_config: None,
         }
     }
 

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -41,7 +41,7 @@ fn test_dummy_vmm_elf() {
         memory_config: default_memory_config(),
         vcpu_config: default_vcpu_config(),
         block_config: None,
-        network_config: None,
+        net_config: None,
     };
     // Sanity check. Because the VMM runs in a separate process, if the file doesn't exist,
     // all we see is a different exit code than 0.
@@ -59,7 +59,7 @@ fn test_dummy_vmm_bzimage() {
         memory_config: default_memory_config(),
         vcpu_config: default_vcpu_config(),
         block_config: None,
-        network_config: None,
+        net_config: None,
     };
     assert!(vmm_config.kernel_config.path.as_path().exists());
     run_vmm(pid, vmm_config);


### PR DESCRIPTION
Implemented `Builder` for `VMMConfig`. (Note: This is an early
implementation, more like prototype. But almost all functionality is
present.)

Removed `derive(Default)` from `MemoryConfig`, `KernelConfig` and
`VcpuConfig` and added sensible defaults (memory = 256M, vcpu=1) (derive
default will trivially initialize this to 0 and hence we are required to
take a memory coniguration from CLI launcher).

Brought these changes to `api` (`CLI`) to demonstrate a use.

Removed `required` from 'memory' and 'vcpu' config.

Changed `TryFrom<String>` to `TryFrom<&str>`. Believe this is better
because it's quite possible to get `&str` from `String` than other way
round and in fact often we'll get `&str` from CLI parsing etc. But the
other way round is painful.

Right now passes all 'existing' tests (`cargo test --all`, except one
which likely fails because the right kernel image is not available to
test.)

TODO: Documentation with examples for using the `Builder` and Test cases
for the `Builder`.