### PR TITLE
Use debug! macro instead of printlns and asserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "utils",
  "vm-device",
  "vm-memory",
  "vmm-sys-util",

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -2,3 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 pub mod resource_download;
+
+/// A macro for printing errors only in debug mode.
+#[macro_export]
+#[cfg(debug_assertions)]
+macro_rules! debug {
+    ($( $args:expr ),*) => { eprintln!( $( $args ),* ); }
+}
+
+/// A macro that allows printing to be ignored in release mode.
+#[macro_export]
+#[cfg(not(debug_assertions))]
+macro_rules! debug {
+    ($( $args:expr ),*) => {
+        ()
+    };
+}

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -12,6 +12,7 @@ kvm-bindings = { version = "0.3.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.5.0"
 vm-memory = { version = "0.4.0" }
 vmm-sys-util = "0.6.1"
+utils = { path = "../utils" }
 
 # vm-device is not yet published on crates.io.
 # To make sure that breaking changes to vm-device are not breaking the

--- a/src/vm-vcpu/src/vcpu/mod.rs
+++ b/src/vm-vcpu/src/vcpu/mod.rs
@@ -19,6 +19,8 @@ use vmm_sys_util::errno::Error as Errno;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
 use vmm_sys_util::terminal::Terminal;
 
+use utils::debug;
+
 mod gdt;
 use gdt::*;
 mod interrupts;
@@ -331,7 +333,7 @@ impl KvmVcpu {
                                     .pio_write(PioAddress(addr), data)
                                     .is_err()
                                 {
-                                    eprintln!("Failed to write to serial port");
+                                    debug!("Failed to write to serial port");
                                 }
                             } else if addr == 0x060 || addr == 0x061 || addr == 0x064 {
                                 // Write at the i8042 port.
@@ -352,7 +354,7 @@ impl KvmVcpu {
                                     .pio_read(PioAddress(addr), data)
                                     .is_err()
                                 {
-                                    eprintln!("Failed to read from serial port");
+                                    debug!("Failed to read from serial port");
                                 }
                             } else {
                                 // Read from some other port.
@@ -366,7 +368,7 @@ impl KvmVcpu {
                                 .mmio_read(MmioAddress(addr), data)
                                 .is_err()
                             {
-                                eprintln!("Failed to read from mmio");
+                                debug!("Failed to read from mmio");
                             }
                         }
                         VcpuExit::MmioWrite(addr, data) => {
@@ -377,12 +379,12 @@ impl KvmVcpu {
                                 .mmio_write(MmioAddress(addr), data)
                                 .is_err()
                             {
-                                eprintln!("Failed to write to mmio");
+                                debug!("Failed to write to mmio");
                             }
                         }
-                        other => {
+                        _other => {
                             // Unhandled KVM exit.
-                            eprintln!("Unhandled vcpu exit: {:#?}", other);
+                            debug!("Unhandled vcpu exit: {:#?}", _other);
                         }
                     }
                 }
@@ -395,7 +397,7 @@ impl KvmVcpu {
                             interrupted_by_signal = true;
                         }
                         _ => {
-                            eprintln!("Emulation error: {}", e);
+                            debug!("Emulation error: {}", e);
                             break;
                         }
                     }


### PR DESCRIPTION
Defined a helper macro that prints errors only when in debug mode. This is necessary for situations in which we are dealing with potentially malicious input.

The macro is now used in two scenarios:
- for the serial console to print error messages regarding invalid reads/writes
- for handling errors in vcpu exits.