### PR TITLE
Add piping guest STDIN/STDOUT to named pipes support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 [[package]]
 name = "utils"
 version = "0.1.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "vec_map"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 59.8,
+  "coverage_score": 60.0,
   "exclude_path": "src/vm-vcpu-ref/,tests/,bindings.rs",
   "crate_features": ""
 }

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -50,6 +50,13 @@ impl Cli {
                     .required(false)
                     .takes_value(true)
                     .help("Block device configuration. \n\tFormat: \"path=<string>\"")
+            )
+            .arg(
+                Arg::with_name("serial")
+                    .long("serial")
+                    .required(false)
+                    .takes_value(true)
+                    .help("Serial device configuration. \n\tFormat: \"serial_input=<string>,serial_output=<string>\"")
             );
 
         // Save the usage beforehand as a string, because `get_matches` consumes the `App`.
@@ -69,6 +76,7 @@ impl Cli {
             .vcpu_config(matches.value_of("vcpu"))
             .net_config(matches.value_of("net"))
             .block_config(matches.value_of("block"))
+            .serial_config(matches.value_of("serial"))
             .build()
             .map_err(|e| format!("{:?}", e))
     }
@@ -82,7 +90,7 @@ mod tests {
 
     use linux_loader::cmdline::Cmdline;
 
-    use vmm::{KernelConfig, MemoryConfig, VcpuConfig, DEFAULT_KERNEL_LOAD_ADDR};
+    use vmm::{KernelConfig, MemoryConfig, SerialConfig, VcpuConfig, DEFAULT_KERNEL_LOAD_ADDR};
 
     #[test]
     fn test_launch() {
@@ -236,6 +244,7 @@ mod tests {
                 vcpu_config: VcpuConfig { num: 1 },
                 block_config: None,
                 net_config: None,
+                serial_config: SerialConfig::default(),
             }
         );
 
@@ -252,6 +261,7 @@ mod tests {
                 vcpu_config: VcpuConfig { num: 1 },
                 block_config: None,
                 net_config: None,
+                serial_config: SerialConfig::default(),
             }
         );
     }

--- a/src/devices/src/legacy/console.rs
+++ b/src/devices/src/legacy/console.rs
@@ -1,0 +1,81 @@
+// Copyright 2020 Sartura All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use crate::legacy::pipe::{PipeReaderWrapper, PipeWriterWrapper};
+use std::io::{stdin, stdout, Read, Write};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::path::PathBuf;
+
+use utils::debug;
+
+/// A generic type used for wrapping the guest input implementation
+/// (stdin, named pipe, unix socket etc.)
+pub struct ConsoleReaderWrapper {
+    reader: Option<PipeReaderWrapper>,
+}
+
+impl ConsoleReaderWrapper {
+    pub fn new(buf: Option<PathBuf>) -> ConsoleReaderWrapper {
+        match buf {
+            None => ConsoleReaderWrapper { reader: None },
+            Some(x) => ConsoleReaderWrapper {
+                reader: match PipeReaderWrapper::new(x) {
+                    Ok(p) => Some(p),
+                    Err(_err) => {
+                        debug!("ConsoleReaderWrapper failed with error {} to create a pipe reader, defaulting to stdin!", _err);
+                        None
+                    }
+                },
+            },
+        }
+    }
+}
+
+impl Read for ConsoleReaderWrapper {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self.reader.as_mut() {
+            None => stdin().read(buf),
+            Some(x) => x.read(buf),
+        }
+    }
+}
+
+impl AsRawFd for ConsoleReaderWrapper {
+    fn as_raw_fd(&self) -> RawFd {
+        match &self.reader {
+            None => stdin().as_raw_fd(),
+            Some(x) => x.as_raw_fd(),
+        }
+    }
+}
+
+/// A generic type used for wrapping the guest output implementation
+/// (stdout, named pipe, unix socket etc.)
+pub struct ConsoleWriterWrapper {
+    writer: Box<dyn Write + Send>,
+}
+
+impl ConsoleWriterWrapper {
+    pub fn new(buf: Option<PathBuf>) -> ConsoleWriterWrapper {
+        let writer_obj: Box<dyn Write + Send> = match buf {
+            None => Box::new(stdout()),
+            Some(x) => match PipeWriterWrapper::new(x) {
+                Ok(p) => Box::new(p),
+                Err(_err) => {
+                    debug!("ConsoleWriterWrapper failed with error {} to create a pipe writer, defaulting to stdout!", _err);
+                    Box::new(stdout())
+                }
+            },
+        };
+        ConsoleWriterWrapper { writer: writer_obj }
+    }
+}
+
+impl Write for ConsoleWriterWrapper {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.writer.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
+    }
+}

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -1,10 +1,13 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+mod console;
+mod pipe;
 #[cfg(target_arch = "aarch64")]
 mod rtc;
 mod serial;
 
+pub use console::{ConsoleReaderWrapper, ConsoleWriterWrapper};
 #[cfg(target_arch = "aarch64")]
 pub use rtc::RtcWrapper;
 pub use serial::Error as SerialError;

--- a/src/devices/src/legacy/pipe.rs
+++ b/src/devices/src/legacy/pipe.rs
@@ -1,0 +1,138 @@
+// Copyright 2020 Sartura All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::path::PathBuf;
+
+/// A wrapper structure around that provides basic read functionality backed by
+/// a named pipe implementation.
+pub struct PipeReaderWrapper(File);
+
+impl PipeReaderWrapper {
+    pub fn new(buf: PathBuf) -> std::io::Result<PipeReaderWrapper> {
+        match utils::mkfifo(&buf, libc::S_IRWXO) {
+            Ok(_) => Ok(PipeReaderWrapper(
+                OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .open(&buf)?,
+            )),
+            Err(fifo_err) => match fifo_err {
+                utils::FifoError::Io(error) => Err(error),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "unknown error",
+                )),
+            },
+        }
+    }
+}
+
+impl Read for PipeReaderWrapper {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl AsRawFd for PipeReaderWrapper {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+/// A wrapper structure around that provides basic write functionality backed by
+/// a named pipe implementation.
+pub struct PipeWriterWrapper(PathBuf);
+
+impl PipeWriterWrapper {
+    pub fn new(buf: PathBuf) -> std::io::Result<PipeWriterWrapper> {
+        match utils::mkfifo(&buf, libc::S_IRWXO) {
+            Ok(_) => Ok(PipeWriterWrapper(buf)),
+            Err(fifo_err) => match fifo_err {
+                utils::FifoError::Io(error) => Err(error),
+                _ => Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "unknown error",
+                )),
+            },
+        }
+    }
+}
+
+impl Write for PipeWriterWrapper {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut pipe = match File::create(&self.0) {
+            Err(err) => {
+                println!("couldn't open pipe: {}", err);
+                return Err(err);
+            }
+            Ok(input) => input,
+        };
+        pipe.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        //Flushing a pipe is meaningles
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::legacy::pipe::{PipeReaderWrapper, PipeWriterWrapper};
+    use std::fs::{remove_file, File};
+    use std::io::{Read, Write};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn test_pipe_read() {
+        let t = std::thread::spawn(move || {
+            let write_buffer: [u8; 1] = [1];
+            while !Path::new("test_in").exists() {}
+            let mut output = match File::create("test_in") {
+                Err(err) => panic!("couldn't open pipe: {}", err),
+                Ok(input) => input,
+            };
+            let res = output.write(&write_buffer);
+            assert!(res.is_ok());
+            drop(output);
+        });
+        let mut read_buffer: [u8; 1] = [0];
+        let input_pipe_path = PathBuf::from("test_in");
+        let mut input = PipeReaderWrapper::new(input_pipe_path).unwrap();
+        let res = input.read(&mut read_buffer);
+        assert!(res.is_ok());
+        assert_eq!(read_buffer[0], 1);
+        drop(input);
+        let res = remove_file("test_in");
+        assert!(res.is_ok());
+        t.join().unwrap();
+    }
+    #[test]
+    fn test_pipe_write() {
+        let t = std::thread::spawn(move || {
+            let mut read_buffer: [u8; 1] = [0];
+            while !Path::new("test_out").exists() {}
+            let mut input = match File::open("test_out") {
+                Err(err) => panic!("couldn't open pipe: {}", err),
+                Ok(input) => input,
+            };
+            let res = input.read(&mut read_buffer);
+            assert!(res.is_ok());
+            assert_eq!(read_buffer[0], 1);
+            drop(input);
+            let res = remove_file("test_out");
+            assert!(res.is_ok());
+        });
+        let write_buffer: [u8; 1] = [1];
+        let output_pipe_path = PathBuf::from("test_out");
+        let mut output = PipeWriterWrapper::new(output_pipe_path).unwrap();
+        let res = output.write(&write_buffer);
+        assert!(res.is_ok());
+        drop(output);
+        t.join().unwrap();
+    }
+}

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 edition = "2018"
 
 [dependencies]
+libc = "0.2.91"

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -1,8 +1,13 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+use std::ffi::CString;
+use std::path::Path;
+use std::{io, result};
+
 pub mod resource_download;
 
+// -----------------------------------------------------------------------------
 /// A macro for printing errors only in debug mode.
 #[macro_export]
 #[cfg(debug_assertions)]
@@ -17,4 +22,37 @@ macro_rules! debug {
     ($( $args:expr ),*) => {
         ()
     };
+}
+
+// -----------------------------------------------------------------------------
+/// Enum containing error types.
+pub enum FifoError {
+    Io(io::Error),
+    Path,
+}
+
+impl std::fmt::Display for FifoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Erorr: {}", (*self))
+    }
+}
+
+/// A safe wrapper around libc::mkfifo().
+pub fn mkfifo<P: AsRef<Path>>(fifo_path: P, mode: u32) -> result::Result<(), FifoError> {
+    let fifo_path_str = fifo_path.as_ref().to_str().ok_or(FifoError::Path)?;
+    match CString::new(fifo_path_str) {
+        Ok(fifo_path_cstr) => {
+            // fifo_path_cstr was checked to be valid and the return of the unsafe code was checked
+            let ret = unsafe { libc::mkfifo(fifo_path_cstr.as_ptr(), mode) };
+            if ret != 0 {
+                Err(FifoError::Io(io::Error::last_os_error()))
+            } else {
+                Ok(())
+            }
+        }
+        Err(_) => Err(FifoError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "pipe name cannot contain null-bytes",
+        ))),
+    }
 }

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -4,7 +4,9 @@ use std::convert::TryFrom;
 use std::path::PathBuf;
 
 use utils::resource_download::s3_download;
-use vmm::{KernelConfig, MemoryConfig, VMMConfig, VcpuConfig, Vmm, DEFAULT_KERNEL_LOAD_ADDR};
+use vmm::{
+    KernelConfig, MemoryConfig, SerialConfig, VMMConfig, VcpuConfig, Vmm, DEFAULT_KERNEL_LOAD_ADDR,
+};
 
 fn default_memory_config() -> MemoryConfig {
     MemoryConfig { size_mib: 1024 }
@@ -29,6 +31,7 @@ fn run_vmm(kernel_path: PathBuf) {
         vcpu_config: default_vcpu_config(),
         block_config: None,
         net_config: None,
+        serial_config: SerialConfig::default(),
     };
 
     let mut vmm = Vmm::try_from(vmm_config).unwrap();


### PR DESCRIPTION
This PR adds support for piping guest STDIN/STDOUT to named pipes so it can be consumed there. When named pipes are enabled the starting process of the guest VM is:

1. The VMM creates a FIFO (Named pipe) for its input.
2. The VMM opens the FIFO for reading, which blocks until a producer opens the FIFO for writing.
3. The VMM creates a FIFO (Named pipe) for its output.
4. If the guest VM has anything to write the VMM opens the FIFO for writing, writes to it and closes it afterwards.

Also, tests for this scenario has been added to integration tests - `tests/test_run_reference_vmm.py::test_serial_console_piping` where this process is shown.