### PR TITLE
Updated existing prints to make use of log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ license = "Apache-2.0 OR BSD-3-Clause"
 [dependencies]
 vmm = { path = "src/vmm" }
 api = { path = "src/api" }
+log = "0.4.14"
+simple_logger = "1.11.0"
 
 [workspace]
 

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.3"
+log = "0.4.14"
+simple_logger = "1.11.0"
 
 vmm = { path = "../vmm" }

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -8,6 +8,8 @@
 #![deny(missing_docs)]
 use std::result;
 
+use log::error;
+
 use clap::{App, Arg};
 use vmm::VMMConfig;
 
@@ -62,7 +64,7 @@ impl CLI {
         let help_msg = String::from_utf8_lossy(&help_msg_buf);
 
         let matches = app.get_matches_from_safe(cmdline_args).map_err(|e| {
-            eprintln!("{}", help_msg);
+            error!("{}", help_msg);
             format!("Invalid command line arguments: {}", e)
         })?;
 

--- a/src/devices/src/virtio/block/inorder_handler.rs
+++ b/src/devices/src/virtio/block/inorder_handler.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::result;
 
 use log::warn;
+
 use vm_memory::{self, Bytes, GuestAddressSpace};
 use vm_virtio::block::request::Request;
 use vm_virtio::block::stdio_executor::{self, StdIoBackend};

--- a/src/devices/src/virtio/block/queue_handler.rs
+++ b/src/devices/src/virtio/block/queue_handler.rs
@@ -1,8 +1,9 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-use event_manager::{EventOps, Events, MutEventSubscriber};
 use log::error;
+
+use event_manager::{EventOps, Events, MutEventSubscriber};
 use vm_memory::GuestAddressSpace;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;

--- a/src/devices/src/virtio/net/queue_handler.rs
+++ b/src/devices/src/virtio/net/queue_handler.rs
@@ -1,8 +1,9 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-use event_manager::{EventOps, Events, MutEventSubscriber};
 use log::error;
+
+use event_manager::{EventOps, Events, MutEventSubscriber};
 use vm_memory::GuestAddressSpace;
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;

--- a/src/devices/src/virtio/net/simple_handler.rs
+++ b/src/devices/src/virtio/net/simple_handler.rs
@@ -6,6 +6,7 @@ use std::io::{self, Read, Write};
 use std::result;
 
 use log::warn;
+
 use vm_memory::{Bytes, GuestAddressSpace};
 use vm_virtio::{DescriptorChain, Queue};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,21 @@ use std::convert::TryFrom;
 #[cfg(target_arch = "x86_64")]
 use std::env;
 
+use simple_logger::SimpleLogger;
+use log::{LevelFilter, error};
+
 #[cfg(target_arch = "x86_64")]
 use api::CLI;
 #[cfg(target_arch = "x86_64")]
 use vmm::VMM;
 
 fn main() {
+    if cfg!(debug_assertions) {
+        SimpleLogger::new().with_level(LevelFilter::Trace).init().unwrap();
+    } else {
+        SimpleLogger::new().with_level(LevelFilter::Info).init().unwrap();
+    }
+
     #[cfg(target_arch = "x86_64")]
     {
         match CLI::launch(
@@ -28,10 +37,10 @@ fn main() {
                 vmm.run().unwrap();
             }
             Err(e) => {
-                eprintln!("Failed to parse command line options. {}", e);
+                error!("Failed to parse command line options. {}", e);
             }
         }
     }
     #[cfg(target_arch = "aarch64")]
-    println!("Reference VMM under construction!")
+    error!("Reference VMM under construction!")
 }

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -2,19 +2,3 @@
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 pub mod resource_download;
-
-/// A macro for printing errors only in debug mode.
-#[macro_export]
-#[cfg(debug_assertions)]
-macro_rules! debug {
-    ($( $args:expr ),*) => { eprintln!( $( $args ),* ); }
-}
-
-/// A macro that allows printing to be ignored in release mode.
-#[macro_export]
-#[cfg(not(debug_assertions))]
-macro_rules! debug {
-    ($( $args:expr ),*) => {
-        ()
-    };
-}

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 libc = "0.2.76"
 kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.8.0"
+log = "0.4.14"
+simple_logger = "1.11.0"
 vm-memory = "0.5.0"
 vmm-sys-util = "0.8.0"
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -11,6 +11,8 @@ kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.8.0"
 libc = "0.2.91"
 linux-loader = { version = "0.3.0", features = ["bzimage", "elf"] }
+log = "0.4.14"
+simple_logger = "1.11.0"
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
 vm-superio = "0.1.1"
 vmm-sys-util = "0.8.0"

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -15,6 +15,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+use log::warn;
+
 use event_manager::{EventManager, EventOps, Events, MutEventSubscriber, SubscriberOps};
 use kvm_bindings::{KVM_API_VERSION, KVM_MAX_CPUID_ENTRIES};
 use kvm_ioctls::{
@@ -276,14 +278,14 @@ impl VMM {
         let kernel_load_addr = self.compute_kernel_load_addr(&load_result)?;
 
         if stdin().lock().set_raw_mode().is_err() {
-            eprintln!("Failed to set raw mode on terminal. Stdin will echo.");
+            warn!("Failed to set raw mode on terminal. Stdin will echo.");
         }
 
         self.vm.run(kernel_load_addr).map_err(Error::Vm)?;
         loop {
             match self.event_mgr.run() {
                 Ok(_) => (),
-                Err(e) => eprintln!("Failed to handle events: {:?}", e),
+                Err(e) => warn!("Failed to handle events: {:?}", e),
             }
             if !self.exit_handler.keep_running() {
                 break;


### PR DESCRIPTION
Imported the `log` and `simple_logger` crates and updated existing print statements to use it in reference to this [issue](https://github.com/rust-vmm/vmm-reference/issues/79). Supported macros include `error!`, `warn!`, `info!`, `debug!`, and `trace!`. The custom `debug!` macro used previously has been replaced with the equivalent in log. Logging level is set in `main.rs` based on the `debug_assertions` read in. When running in release mode, only macros `error!`, `warn!`, and `info!` will print information.

This is the first time tumbleshack and I have contributed to this project. We've tried to be consistent with existing conventions, but if we've made a mistake please let us know - we're happy to learn and fix it.

Signed-off-by: Sean Walsh <seanmichwalsh@protonmail.ch>