### PR TITLE
main: Handle errors gracefully in main()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,10 +10,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+
+[[package]]
 name = "api"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "thiserror",
  "vmm",
 ]
 
@@ -140,10 +147,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "syn"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "textwrap"
@@ -155,10 +191,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "utils"
@@ -230,6 +292,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
+ "thiserror",
  "utils",
  "vm-device",
  "vm-memory",
@@ -242,6 +305,7 @@ dependencies = [
 name = "vmm-reference"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "api",
  "vmm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "Apache-2.0 OR BSD-3-Clause"
 
 [dependencies]
+anyhow = "1.0"
 vmm = { path = "src/vmm" }
 api = { path = "src/api" }
 

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.3"
+thiserror = "1.0"
 
 vmm = { path = "../vmm" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,44 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
-#[cfg(target_arch = "x86_64")]
-use std::convert::TryFrom;
-#[cfg(target_arch = "x86_64")]
-use std::env;
 
 #[cfg(target_arch = "x86_64")]
-use api::CLI;
-#[cfg(target_arch = "x86_64")]
-use vmm::VMM;
+mod main {
+    use std::convert::TryFrom;
+    use std::env;
 
-fn main() {
-    #[cfg(target_arch = "x86_64")]
-    {
-        match CLI::launch(
+    use api::CLI;
+    use vmm::VMM;
+
+    use anyhow::Context;
+
+    pub type Result<T> = anyhow::Result<T>;
+
+    pub fn run() -> Result<()> {
+        let vmm_config = CLI::launch(
             env::args()
                 .collect::<Vec<String>>()
                 .iter()
                 .map(|s| s.as_str())
                 .collect(),
-        ) {
-            Ok(vmm_config) => {
-                let mut vmm =
-                    VMM::try_from(vmm_config).expect("Failed to create VMM from configurations");
-                // For now we are just unwrapping here, in the future we might use a nicer way of
-                // handling errors such as pretty printing them.
-                vmm.run().unwrap();
-            }
-            Err(e) => {
-                eprintln!("Failed to parse command line options. {}", e);
-            }
-        }
+        )
+        .context("Failed to parse CLI options")?;
+
+        let mut vmm =
+            VMM::try_from(vmm_config).context("Failed to create VMM from configurations")?;
+
+        vmm.run().context("failed to run VMM")
     }
-    #[cfg(target_arch = "aarch64")]
-    println!("Reference VMM under construction!")
+}
+
+#[cfg(target_arch = "aarch64")]
+mod main {
+    pub type Result<T> = std::result::Result<T, String>;
+    pub fn run() -> Result<()> {
+        println!("Reference VMM under construction!");
+        Ok(())
+    }
+}
+
+fn main() -> main::Result<()> {
+    main::run()
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 edition = "2018"
 
 [dependencies]
+thiserror = "1.0"
 
 event-manager = "0.2.1"
 kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -49,6 +49,8 @@ use serial::SerialWrapper;
 use vm_vcpu::vcpu::{cpuid::filter_cpuid, VcpuState};
 use vm_vcpu::vm::{self, ExitHandler, KvmVm, VmState};
 
+use thiserror::Error;
+
 mod boot;
 mod config;
 
@@ -81,41 +83,58 @@ pub enum MemoryError {
 }
 
 /// VMM errors.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum Error {
     /// Failed to create block device.
+    #[error("Failed to create block device {0:?}.")]
     Block(block::Error),
     /// Failed to write boot parameters to guest memory.
+    #[error("Failed to write boot parameters to guest memory {0:?}.")]
     BootConfigure(configurator::Error),
     /// Error configuring boot parameters.
+    #[error("Error configuring boot parameters {0:?}.")]
     BootParam(boot::Error),
     /// Error configuring the kernel command line.
+    #[error("Error configuring the kernel command line {0:?}.")]
     Cmdline(cmdline::Error),
     /// Error setting up devices.
+    #[error("Error setting up devices {0:?}.")]
     Device(serial::Error),
     /// Event management error.
+    #[error("Event management error {0}.")]
     EventManager(event_manager::Error),
     /// I/O error.
+    #[error("I/O error {0}.")]
     IO(io::Error),
     /// Failed to load kernel.
+    #[error("Failed to load kernel {0}.")]
     KernelLoad(loader::Error),
     /// Failed to create net device.
+    #[error("Failed to create net device {0:?}.")]
     Net(net::Error),
     /// Address stored in the rip registry does not fit in guest memory.
+    #[error("Address stored in the rip registry does not fit in guest memory.")]
     RipOutOfGuestMemory,
     /// Invalid KVM API version.
+    #[error("Invalid KVM API version {0}.")]
     KvmApiVersion(i32),
     /// Unsupported KVM capability.
+    #[error("Unsupported KVM capability {0:?}.")]
     KvmCap(Cap),
     /// Error issuing an ioctl to KVM.
+    #[error("Error issuing an ioctl to KVM {0:?}.")]
     KvmIoctl(kvm_ioctls::Error),
     /// Memory error.
+    #[error("Memory error {0:?}.")]
     Memory(MemoryError),
     /// Invalid number of vCPUs specified.
+    #[error("Invalid number of vCPUs specified {0:?}.")]
     VcpuNumber(u8),
     /// VM errors.
+    #[error("VM errors {0:?}.")]
     Vm(vm::Error),
     /// Exit event errors.
+    #[error("Exit event errors {0:?}.")]
     ExitEvent(io::Error),
 }
 


### PR DESCRIPTION
Handle calls to `CLI`, `VMM::try_from()`  and` vmm.run()`.

This commit adds `anyhow` and `thiserror` crates to
handle errors.

The `anyhow` crate is used in the main binary to add
extra context and give a pretty view of error trace.

The create `thiserror` was used to easily
derive `std::error::Error` for errors provided by libs.

The new crates pulls the following extra crates:
```diff
+name = "proc-macro2"
+name = "quote"
+name = "syn"
+name = "thiserror-impl"
+name = "unicode-xid"
```

New error format:
examples:
```sh
$ vmm-reference --kernel \
    path=/path/vmlinuz-5.10.25
Error: Failed to create VMM from configurations

Caused by:
    Error issuing an ioctl to KVM.

$ echo $?
1
```

```sh
$ vmm-reference --kernel path
Error: Failed to parse CLI options

Caused by:
    Failed to parse cli Invalid input for kernel: Missing required
    argument: path
```

```
$vmm-reference
Error: Failed to parse CLI options

Caused by:
    Failed to parse cli error: The following required arguments were not provided:
        --kernel <kernel>

    USAGE:
        vmm-reference [OPTIONS] --kernel <kernel>

    For more information try --help
```

Fixes: #99

Signed-off-by: Carlos Venegas <jose.carlos.venegas.munoz@intel.com>