### PR TITLE
Update vm-virtio paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,12 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "byteorder"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,9 +64,11 @@ dependencies = [
  "libc",
  "linux-loader",
  "log",
+ "virtio-blk",
+ "virtio-device",
+ "virtio-queue",
  "vm-device",
  "vm-memory",
- "vm-virtio",
  "vmm-sys-util",
 ]
 
@@ -171,6 +167,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "virtio-blk"
+version = "0.1.0"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#333eb78471a7707df7d277b9116073337df19503"
+dependencies = [
+ "log",
+ "virtio-device",
+ "virtio-queue",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "virtio-device"
+version = "0.1.0"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#333eb78471a7707df7d277b9116073337df19503"
+dependencies = [
+ "log",
+ "virtio-queue",
+ "vm-memory",
+]
+
+[[package]]
+name = "virtio-queue"
+version = "0.1.0"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#333eb78471a7707df7d277b9116073337df19503"
+dependencies = [
+ "log",
+ "vm-memory",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "vm-device"
 version = "0.1.0"
 source = "git+https://github.com/rust-vmm/vm-device?rev=5847f12#5847f1286492b7191f1400e6647fb220f8941f89"
@@ -204,18 +232,6 @@ dependencies = [
  "libc",
  "utils",
  "vm-device",
- "vm-memory",
- "vmm-sys-util",
-]
-
-[[package]]
-name = "vm-virtio"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-virtio.git#7b5fd44d802408212d746eaa3e41ad2f22477a7a"
-dependencies = [
- "byteorder",
- "libc",
- "log",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -19,7 +19,9 @@ vmm-sys-util = "0.8.0"
 # vm-vcpu build, we're using a fixed revision.
 vm-device = { git = "https://github.com/rust-vmm/vm-device", rev = "5847f12" }
 
-vm-virtio = { git = "https://github.com/rust-vmm/vm-virtio.git", features = ["backend-stdio"] }
+virtio-blk = { git = "https://github.com/rust-vmm/vm-virtio.git", features = ["backend-stdio"] }
+virtio-device = { git = "https://github.com/rust-vmm/vm-virtio.git"}
+virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio.git"}
 
 [dev-dependencies]
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -7,13 +7,13 @@ use std::ops::DerefMut;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use virtio_blk::stdio_executor::StdIoBackend;
+use virtio_device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
+use virtio_queue::Queue;
 use vm_device::bus::MmioAddress;
 use vm_device::device_manager::MmioManager;
 use vm_device::{DeviceMmio, MutDeviceMmio};
 use vm_memory::GuestAddressSpace;
-use vm_virtio::block::stdio_executor::StdIoBackend;
-use vm_virtio::device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
-use vm_virtio::Queue;
 
 use crate::virtio::block::{BLOCK_DEVICE_ID, VIRTIO_BLK_F_RO};
 use crate::virtio::{CommonConfig, Env, SingleFdSignalQueue, QUEUE_MAX_SIZE};

--- a/src/devices/src/virtio/block/inorder_handler.rs
+++ b/src/devices/src/virtio/block/inorder_handler.rs
@@ -5,17 +5,17 @@ use std::fs::File;
 use std::result;
 
 use log::warn;
+use virtio_blk::request::Request;
+use virtio_blk::stdio_executor::{self, StdIoBackend};
+use virtio_queue::{DescriptorChain, Queue};
 use vm_memory::{self, Bytes, GuestAddressSpace};
-use vm_virtio::block::request::Request;
-use vm_virtio::block::stdio_executor::{self, StdIoBackend};
-use vm_virtio::{DescriptorChain, Queue};
 
 use crate::virtio::SignalUsedQueue;
 
 #[derive(Debug)]
 pub enum Error {
     GuestMemory(vm_memory::GuestMemoryError),
-    Queue(vm_virtio::Error),
+    Queue(virtio_queue::Error),
 }
 
 impl From<vm_memory::GuestMemoryError> for Error {
@@ -24,8 +24,8 @@ impl From<vm_memory::GuestMemoryError> for Error {
     }
 }
 
-impl From<vm_virtio::Error> for Error {
-    fn from(e: vm_virtio::Error) -> Self {
+impl From<virtio_queue::Error> for Error {
+    fn from(e: virtio_queue::Error) -> Self {
         Error::Queue(e)
     }
 }
@@ -94,7 +94,7 @@ where
 
     pub fn process_queue(&mut self) -> result::Result<(), Error> {
         // To see why this is done in a loop, please look at the `Queue::enable_notification`
-        // comments in `vm_virtio`.
+        // comments in `virtio_queue`.
         loop {
             self.queue.disable_notification()?;
 

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 use std::io::{self, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
-use vm_virtio::block::stdio_executor;
+use virtio_blk::stdio_executor;
 
 use crate::virtio::features::{VIRTIO_F_IN_ORDER, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1};
 

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -18,11 +18,11 @@ use event_manager::{
 };
 use kvm_ioctls::{IoEventAddress, VmFd};
 use linux_loader::cmdline::Cmdline;
+use virtio_device::VirtioConfig;
 use vm_device::bus::{self, MmioAddress, MmioRange};
 use vm_device::device_manager::MmioManager;
 use vm_device::DeviceMmio;
 use vm_memory::{GuestAddress, GuestAddressSpace};
-use vm_virtio::device::VirtioConfig;
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
@@ -277,7 +277,7 @@ pub(crate) mod tests {
     use vm_memory::{GuestAddress, GuestMemoryMmap};
 
     use event_manager::{EventOps, Events};
-    use vm_virtio::Queue;
+    use virtio_queue::Queue;
 
     use super::features::VIRTIO_F_VERSION_1;
     use super::*;

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -5,12 +5,12 @@ use std::borrow::{Borrow, BorrowMut};
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
 
+use virtio_device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
+use virtio_queue::Queue;
 use vm_device::bus::MmioAddress;
 use vm_device::device_manager::MmioManager;
 use vm_device::{DeviceMmio, MutDeviceMmio};
 use vm_memory::GuestAddressSpace;
-use vm_virtio::device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
-use vm_virtio::Queue;
 
 use crate::virtio::features::{VIRTIO_F_IN_ORDER, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1};
 use crate::virtio::net::features::*;

--- a/src/devices/src/virtio/net/simple_handler.rs
+++ b/src/devices/src/virtio/net/simple_handler.rs
@@ -6,8 +6,8 @@ use std::io::{self, Read, Write};
 use std::result;
 
 use log::warn;
+use virtio_queue::{DescriptorChain, Queue};
 use vm_memory::{Bytes, GuestAddressSpace};
-use vm_virtio::{DescriptorChain, Queue};
 
 use crate::virtio::net::tap::Tap;
 use crate::virtio::net::{RXQ_INDEX, TXQ_INDEX};
@@ -25,12 +25,12 @@ const MAX_BUFFER_SIZE: usize = 65562;
 #[derive(Debug)]
 pub enum Error {
     GuestMemory(vm_memory::GuestMemoryError),
-    Queue(vm_virtio::Error),
+    Queue(virtio_queue::Error),
     Tap(io::Error),
 }
 
-impl From<vm_virtio::Error> for Error {
-    fn from(e: vm_virtio::Error) -> Self {
+impl From<virtio_queue::Error> for Error {
+    fn from(e: virtio_queue::Error) -> Self {
         Error::Queue(e)
     }
 }


### PR DESCRIPTION
The vm-virtio paths need to be updated after vm-virtio was split into
several crates [here](https://github.com/rust-vmm/vm-virtio/pull/58)  .
