### PR TITLE
Explicitly add rw to cmdline

### DIFF
--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -91,6 +91,8 @@ impl BlockArgs {
 
             if self.read_only {
                 s.push_str(" ro");
+            } else {
+                s.push_str(" rw");
             }
         }
         s
@@ -178,6 +180,6 @@ mod tests {
         assert_eq!(args.cmdline_config_substring(), "root=/dev/vda ro");
 
         args.read_only = false;
-        assert_eq!(args.cmdline_config_substring(), "root=/dev/vda");
+        assert_eq!(args.cmdline_config_substring(), "root=/dev/vda rw");
     }
 }


### PR DESCRIPTION
Ubuntu (bzimage, ext4) VM boot time takes too long since the file system is mounted read-only.
As a workaround, this patch enforces `rw` to the command line if the virtio-blk is not configured to be read-only

Related to #46