### PR TITLE
Explicitly add rw flag to cmdline for root

### DIFF
--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -91,6 +91,8 @@ impl BlockArgs {
 
             if self.read_only {
                 s.push_str(" ro");
+            } else {
+                s.push_str(" rw");
             }
         }
         s
@@ -178,6 +180,6 @@ mod tests {
         assert_eq!(args.cmdline_config_substring(), "root=/dev/vda ro");
 
         args.read_only = false;
-        assert_eq!(args.cmdline_config_substring(), "root=/dev/vda");
+        assert_eq!(args.cmdline_config_substring(), "root=/dev/vda rw");
     }
 }

--- a/tests/test_run_reference_vmm.py
+++ b/tests/test_run_reference_vmm.py
@@ -88,7 +88,7 @@ and run locally.
 
 def start_vmm_process(kernel_path, disk_path=None, num_vcpus=1, mem_size_mib=1024):
     # Kernel config
-    cmdline = "console=ttyS0 i8042.nokbd reboot=t panic=1 pci=off rw"
+    cmdline = "console=ttyS0 i8042.nokbd reboot=t panic=1 pci=off"
 
     himem_start = 1048576
 


### PR DESCRIPTION
This prevents the root fs from being mounted read-only
if no flags are given. Related to #46.