### PR TITLE
Upgrade vm-superio to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,13 +215,9 @@ dependencies = [
 
 [[package]]
 name = "vm-superio"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d690c241393f2b9cbe4d37279c8b994fdf244faa15c71f4a7196632880324c77"
-dependencies = [
- "libc",
- "vmm-sys-util",
-]
+checksum = "e04e8579e93095777eaf185dcfe0d9cfa824615be0100af4f965b7e35bdffd04"
 
 [[package]]
 name = "vm-vcpu"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 69.3,
+  "coverage_score": 69.6,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/,src/devices/src/virtio/net/bindings.rs",
   "crate_features": ""
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -12,7 +12,7 @@ kvm-ioctls = "0.8.0"
 libc = "0.2.91"
 linux-loader = { version = "0.3.0", features = ["bzimage", "elf"] }
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
-vm-superio = "0.1.1"
+vm-superio = "0.3.0"
 vmm-sys-util = "0.8.0"
 
 # vm-device is not yet published on crates.io.


### PR DESCRIPTION
Solves #125

Upgrade vm-superio to 0.3.0. As part of vm-superio changes, implemented the `Trigger` trait to be able to initialize the Serial Console. Initialized the devices using `NoEvents`
