### PR TITLE
Add pytest timeout

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -2,7 +2,7 @@
     "tests": [
         {
             "test_name": "run",
-            "command": "pytest tests/test_run_reference_vmm.py",
+            "command": "pytest --timeout=60 tests/test_run_reference_vmm.py",
             "platform": [
                 "x86_64"
             ]


### PR DESCRIPTION
Updated the command that runs `test_run_reference_vmm.py` so that it includes a timeout in seconds per test. This means that each test will terminate and be marked as failed after the given timeout.