### PR TITLE
Add the Serial Console and RTC to the MMIO bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,11 +64,13 @@ dependencies = [
  "libc",
  "linux-loader",
  "log",
+ "utils",
  "virtio-blk",
  "virtio-device",
  "virtio-queue",
  "vm-device",
  "vm-memory",
+ "vm-superio",
  "vmm-sys-util",
 ]
 
@@ -215,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "vm-superio"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04e8579e93095777eaf185dcfe0d9cfa824615be0100af4f965b7e35bdffd04"
+checksum = "3be26a7083513b8302a0053a93f03592ec8875803ff312e0bd3a373e1bee4cfd"
 
 [[package]]
 name = "vm-vcpu"

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 70.4,
+  "coverage_score": 70.1,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/,src/devices/src/virtio/net/bindings.rs",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 70.1,
+  "coverage_score": 70.2,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/,src/devices/src/virtio/net/bindings.rs",
   "crate_features": ""
 }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -12,6 +12,7 @@ libc = "0.2.76"
 linux-loader = "0.3.0"
 log = "0.4.6"
 vm-memory = "0.5.0"
+vm-superio = "0.4.0"
 vmm-sys-util = "0.8.0"
 
 # vm-device is not yet published on crates.io.
@@ -22,6 +23,8 @@ vm-device = { git = "https://github.com/rust-vmm/vm-device", rev = "5847f12" }
 virtio-blk = { git = "https://github.com/rust-vmm/vm-virtio.git", features = ["backend-stdio"] }
 virtio-device = { git = "https://github.com/rust-vmm/vm-virtio.git"}
 virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio.git"}
+
+utils = { path = "../utils" }
 
 [dev-dependencies]
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -1,0 +1,40 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+mod serial;
+pub use serial::Error as SerialError;
+pub use serial::SerialWrapper;
+
+use std::io;
+use std::ops::Deref;
+
+use vm_superio::Trigger;
+use vmm_sys_util::eventfd::EventFd;
+
+/// Newtype for implementing the trigger functionality for `EventFd`.
+///
+/// The trigger is used for handling events in the legacy devices.
+pub struct EventFdTrigger(EventFd);
+
+impl Trigger for EventFdTrigger {
+    type E = io::Error;
+
+    fn trigger(&self) -> io::Result<()> {
+        self.write(1)
+    }
+}
+impl Deref for EventFdTrigger {
+    type Target = EventFd;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl EventFdTrigger {
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Ok(EventFdTrigger((**self).try_clone()?))
+    }
+    pub fn new(flag: i32) -> io::Result<Self> {
+        let event_fd = EventFd::new(flag)?;
+        Ok(EventFdTrigger(event_fd))
+    }
+}

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -1,7 +1,12 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+#[cfg(target_arch = "aarch64")]
+mod rtc;
 mod serial;
+
+#[cfg(target_arch = "aarch64")]
+pub use rtc::RtcWrapper;
 pub use serial::Error as SerialError;
 pub use serial::SerialWrapper;
 

--- a/src/devices/src/legacy/rtc.rs
+++ b/src/devices/src/legacy/rtc.rs
@@ -1,0 +1,101 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::convert::TryInto;
+use vm_device::bus::MmioAddress;
+use vm_device::MutDeviceMmio;
+use vm_superio::{rtc_pl031::NoEvents, Rtc};
+
+use utils::debug;
+
+pub struct RtcWrapper(pub Rtc<NoEvents>);
+
+impl MutDeviceMmio for RtcWrapper {
+    fn mmio_read(&mut self, _base: MmioAddress, offset: u64, data: &mut [u8]) {
+        if data.len() != 4 {
+            debug!("RTC invalid data length on read: {}", data.len());
+            return;
+        }
+
+        match offset.try_into() {
+            // The unwrap() is safe because we checked that `data` has length 4.
+            Ok(offset) => self.0.read(offset, data.try_into().unwrap()),
+            Err(_) => debug!("Invalid RTC read offset."),
+        }
+    }
+
+    fn mmio_write(&mut self, _base: MmioAddress, offset: u64, data: &[u8]) {
+        if data.len() != 4 {
+            debug!("RTC invalid data length on write: {}", data.len());
+            return;
+        }
+
+        match offset.try_into() {
+            // The unwrap() is safe because we checked that `data` has length 4.
+            Ok(offset) => self.0.write(offset, data.try_into().unwrap()),
+            Err(_) => debug!("Invalid RTC write offset."),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_requests() {
+        let mut rtc = RtcWrapper(Rtc::new());
+
+        // Check that passing invalid data does not result in a crash.
+        let mut invalid_data = [0; 3];
+        let valid_offset = 0x0;
+        rtc.mmio_read(MmioAddress(0), valid_offset, invalid_data.as_mut());
+        rtc.mmio_write(MmioAddress(0), valid_offset, &invalid_data);
+
+        // Check that passing an invalid offset does not result in a crash.
+        let valid_data = [0; 4];
+        let invalid_offset = u64::MAX;
+        rtc.mmio_write(MmioAddress(0), invalid_offset, &valid_data);
+    }
+
+    #[test]
+    fn test_valid_read() {
+        use core::time::Duration;
+        use std::thread;
+
+        let mut rtc = RtcWrapper(Rtc::new());
+        let mut data = [0; 4];
+        let offset = 0x0;
+
+        // Read the data register.
+        rtc.mmio_read(MmioAddress(0), offset, data.as_mut());
+        let first_read = u32::from_le_bytes(data);
+
+        // Sleep for 1.5 seconds.
+        let delay = Duration::from_millis(1500);
+        thread::sleep(delay);
+
+        // Read the data register again.
+        rtc.mmio_read(MmioAddress(0), offset, data.as_mut());
+        let second_read = u32::from_le_bytes(data);
+
+        assert!(second_read > first_read);
+    }
+
+    #[test]
+    fn test_valid_write() {
+        let mut rtc = RtcWrapper(Rtc::new());
+        let write_data = [1; 4];
+        let mut read_data = [0; 4];
+        let offset = 0x8;
+
+        // Write to and read from the load register.
+        rtc.mmio_write(MmioAddress(0), offset, &write_data);
+        rtc.mmio_read(MmioAddress(0), offset, read_data.as_mut());
+
+        assert_eq!(
+            u32::from_le_bytes(write_data),
+            u32::from_le_bytes(read_data)
+        );
+    }
+}

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -5,4 +5,5 @@
 // we are striving to turn as much of the local code as possible into reusable building blocks
 // going forward.
 
+pub mod legacy;
 pub mod virtio;

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -12,7 +12,7 @@ kvm-ioctls = "0.8.0"
 libc = "0.2.91"
 linux-loader = { version = "0.3.0", features = ["bzimage", "elf"] }
 vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
-vm-superio = "0.3.0"
+vm-superio = "0.4.0"
 vmm-sys-util = "0.8.0"
 
 # vm-device is not yet published on crates.io.


### PR DESCRIPTION
1. Changes to the Serial Console:

    - Moved `serial.rs` to a new directory `src/devices/legacy`

    - Implemented the MMIO trait for the `SerialWrapper`. Previously only the PIO trait was implemented, as on x86_64 the serial is available on the PIO bus. To enable support for aarch64, we needed to add it to the MMIO bus as well

2. Implemented the MMIO trait for `Rtc`, since this device is needed on aarch64.

3. Fixed the `read()` and `write()` functions for the serial device. Previously, these functions wouldn't return if the length of the array parameter `data` was not `1`; they would only log this and then try to access `data[0]`, even if `data` happened to be empty. Changed the functions so that they return after logging and updated the unit tests.

