### PR TITLE
rename high_mem_start to load_addr

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ configurations. Advanced users can, of course, plug in their own front-end.
   * `path` - `String`, path to the guest kernel image
   * `cmdline` - `String`, kernel command line
     * default: "console=ttyS0 i8042.nokbd reboot=t panic=1 pci=off"
-  * `himem_start` - `u64`, start address for high memory (decimal)
+  * `kernel_load_addr` - `u64`, start address for high memory (decimal)
     * default: 0x100000
 * `vcpus` - vCPU configurations
   * `num` - `u8`, number of vCPUs (decimal)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -151,7 +151,7 @@ effort.
 vmm-reference                                                           \
     --memory size_mib=1024                                          \
     --vcpu num=1                                                 \
-    --kernel path=/path/to/vmlinux,himem_start=1024,cmdline="pci=off"   \
+    --kernel path=/path/to/vmlinux,kernel_load_addr=1024,cmdline="pci=off"   \
     [--block <blkdev_config> - TBD]
     [--net <netdev_config> - TBD]
 ```

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -39,7 +39,7 @@ impl Cli {
                     .long("kernel")
                     .required(true)
                     .takes_value(true)
-                    .help("Kernel configuration.\n\tFormat: \"path=<string>[,cmdline=<string>,himem_start=<u64>]\""),
+                    .help("Kernel configuration.\n\tFormat: \"path=<string>[,cmdline=<string>,kernel_load_addr=<u64>]\""),
             )
             .arg(
                 Arg::with_name("net")
@@ -98,7 +98,7 @@ mod tests {
             "--vcpu",
             "num=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42",
             "foobar",
         ])
         .is_err());
@@ -111,7 +111,7 @@ mod tests {
             "--vcpu",
             "num=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42",
         ])
         .is_err());
 
@@ -123,7 +123,7 @@ mod tests {
             "--vcpu",
             "num=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42",
         ])
         .is_ok());
 
@@ -135,11 +135,11 @@ mod tests {
             "--vcpu",
             "num=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42",
         ])
         .is_err());
 
-        // Invalid kernel config: invalid value for `himem_start`.
+        // Invalid kernel config: invalid value for `kernel_load_addr`.
         // TODO: harden cmdline check.
         assert!(Cli::launch(vec![
             "foobar",
@@ -148,11 +148,11 @@ mod tests {
             "--vcpu",
             "num=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=foobar",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=foobar",
         ])
         .is_err());
 
-        // Kernel config: missing value for `himem_start`, use default
+        // Kernel config: missing value for `kernel_load_addr`, use default
         assert!(Cli::launch(vec![
             "foobar",
             "--memory",
@@ -160,7 +160,7 @@ mod tests {
             "--vcpu",
             "num=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=",
         ])
         .is_ok());
 
@@ -172,7 +172,7 @@ mod tests {
             "--vcpu",
             "num=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42,foobar=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42,foobar=42",
         ])
         .is_err());
 
@@ -184,7 +184,7 @@ mod tests {
             "--vcpu",
             "num=foobar",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42",
         ])
         .is_err());
 
@@ -196,7 +196,7 @@ mod tests {
             "--vcpu",
             "num=",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42",
         ])
         .is_ok());
 
@@ -208,7 +208,7 @@ mod tests {
             "--vcpu",
             "foobar=1",
             "--kernel",
-            "path=/foo/bar,cmdline=\"foo=bar\",himem_start=42",
+            "path=/foo/bar,cmdline=\"foo=bar\",kernel_load_addr=42",
         ])
         .is_err());
 
@@ -221,14 +221,14 @@ mod tests {
                 "--vcpu",
                 "num=1",
                 "--kernel",
-                "path=/foo/bar,cmdline=\"foo=bar bar=foo\",himem_start=42",
+                "path=/foo/bar,cmdline=\"foo=bar bar=foo\",kernel_load_addr=42",
             ])
             .unwrap(),
             VMMConfig {
                 kernel_config: KernelConfig {
                     path: PathBuf::from("/foo/bar"),
                     cmdline: "\"foo=bar bar=foo\"".to_string(),
-                    himem_start: 42,
+                    load_addr: 42,
                 },
                 memory_config: MemoryConfig { size_mib: 128 },
                 vcpu_config: VcpuConfig { num: 1 },
@@ -244,7 +244,7 @@ mod tests {
                 kernel_config: KernelConfig {
                     path: PathBuf::from("/foo/bar"),
                     cmdline: DEFAULT_KERNEL_CMDLINE.to_string(),
-                    himem_start: 1048576,
+                    load_addr: 1048576,
                 },
                 memory_config: MemoryConfig { size_mib: 256 },
                 vcpu_config: VcpuConfig { num: 1 },

--- a/src/vmm/src/config/builder.rs
+++ b/src/vmm/src/config/builder.rs
@@ -256,7 +256,7 @@ mod tests {
             vmm_config.unwrap().kernel_config,
             KernelConfig {
                 cmdline: DEFAULT_KERNEL_CMDLINE.to_string(),
-                himem_start: DEFAULT_HIGH_RAM_START,
+                load_addr: DEFAULT_HIGH_RAM_START,
                 path: PathBuf::from("bzImage")
             }
         );
@@ -338,7 +338,7 @@ mod tests {
                 vcpu_config: VcpuConfig { num: 2 },
                 kernel_config: KernelConfig {
                     cmdline: DEFAULT_KERNEL_CMDLINE.to_string(),
-                    himem_start: DEFAULT_HIGH_RAM_START,
+                    load_addr: DEFAULT_HIGH_RAM_START,
                     path: PathBuf::from("bzImage")
                 },
                 net_config: Some(NetConfig {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -68,6 +68,9 @@ const CMDLINE_START: u64 = 0x0002_0000;
 /// Default high memory start (1 MiB).
 pub const DEFAULT_HIGH_RAM_START: u64 = 0x0010_0000;
 
+/// Default address for loading the kernel.
+pub const DEFAULT_KERNEL_LOAD_ADDR: u64 = DEFAULT_HIGH_RAM_START;
+
 /// Default kernel command line.
 pub const DEFAULT_KERNEL_CMDLINE: &str = "i8042.nokbd reboot=t panic=1 pci=off";
 
@@ -355,14 +358,14 @@ impl Vmm {
             &self.guest_memory,
             None,
             &mut kernel_image,
-            Some(GuestAddress(self.kernel_cfg.himem_start)),
+            Some(GuestAddress(self.kernel_cfg.load_addr)),
         ) {
             Ok(result) => result,
             Err(loader::Error::Elf(elf::Error::InvalidElfMagicNumber)) => BzImage::load(
                 &self.guest_memory,
                 None,
                 &mut kernel_image,
-                Some(GuestAddress(self.kernel_cfg.himem_start)),
+                Some(GuestAddress(self.kernel_cfg.load_addr)),
             )
             .map_err(Error::KernelLoad)?,
             Err(e) => {
@@ -374,7 +377,7 @@ impl Vmm {
         let mut bootparams = build_bootparams(
             &self.guest_memory,
             &kernel_load,
-            GuestAddress(self.kernel_cfg.himem_start),
+            GuestAddress(self.kernel_cfg.load_addr),
             GuestAddress(MMIO_GAP_START),
             GuestAddress(MMIO_GAP_END),
         )
@@ -617,7 +620,7 @@ mod tests {
         VMMConfig {
             kernel_config: KernelConfig {
                 path: default_elf_path(),
-                himem_start: DEFAULT_HIGH_RAM_START,
+                load_addr: DEFAULT_HIGH_RAM_START,
                 cmdline: DEFAULT_KERNEL_CMDLINE.to_string(),
             },
             memory_config: MemoryConfig {

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -16,7 +16,7 @@ fn default_memory_config() -> MemoryConfig {
 fn default_kernel_config(path: PathBuf) -> KernelConfig {
     KernelConfig {
         path,
-        himem_start: 0x0010_0000, // 1 MB
+        load_addr: 0x0010_0000, // 1 MB
         cmdline: "console=ttyS0 i8042.nokbd reboot=t panic=1 pci=off".to_string(),
     }
 }

--- a/tests/test_run_reference_vmm.py
+++ b/tests/test_run_reference_vmm.py
@@ -90,7 +90,7 @@ def start_vmm_process(kernel_path, disk_path=None, num_vcpus=1, mem_size_mib=102
     # Kernel config
     cmdline = "console=ttyS0 i8042.nokbd reboot=t panic=1 pci=off"
 
-    himem_start = 1048576
+    kernel_load_addr = 1048576
 
     build_cmd = "cargo build --release"
     subprocess.run(build_cmd, shell=True, check=True)
@@ -98,8 +98,8 @@ def start_vmm_process(kernel_path, disk_path=None, num_vcpus=1, mem_size_mib=102
     vmm_cmd = [
         "target/release/vmm-reference",
         "--memory", "size_mib={}".format(mem_size_mib),
-        "--kernel", "cmdline={},path={},himem_start={}".format(
-            cmdline, kernel_path, himem_start
+        "--kernel", "cmdline={},path={},kernel_load_addr={}".format(
+            cmdline, kernel_path, kernel_load_addr
         ),
         "--vcpu", "num={}".format(num_vcpus)
     ]


### PR DESCRIPTION
This patch is in preparation of adding aarch64 support. Naming the
field load_addr makes it a bit more platform independent.