### PR TITLE
Use `linux_loader::Cmdline` instead of `String`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "linux-loader"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c819cc8275b0f2c1ed9feec455ca288b45d82932384a6a5f7a86812ee3427459"
+checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
 dependencies = [
  "vm-memory",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ source = "git+https://github.com/rust-vmm/vm-device?rev=5847f12#5847f1286492b719
 
 [[package]]
 name = "vm-memory"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625f401b1b8b3ac3d43f53903cd138cfe840bd985f8581e553027b31d2bb8ae8"
+checksum = "0a8ebcb86ca457f9d6e14cf97009f679952eba42f0113de5db596e514cd0e43b"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ name = "api"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "linux-loader",
  "vmm",
 ]
 
@@ -122,8 +123,7 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 [[package]]
 name = "linux-loader"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5e77493808403a6bd56a301a64ea6b9342e36ea845044bf0dfdf56fe52fa08"
+source = "git+https://github.com/rust-vmm/linux-loader.git?rev=9a9f071#9a9f071219a8c74dcd703aec40ba0249e3a5993b"
 dependencies = [
  "vm-memory",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ codegen-units = 1
 lto = true
 panic = "abort"
 
+[patch.crates-io]
+# TODO: Using this patch until a version > 4.0 gets published.
+linux-loader = { git = "https://github.com/rust-vmm/linux-loader.git", rev = "9a9f071" }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 70.2,
+  "coverage_score": 70.4,
   "exclude_path": "msr_index.rs,mpspec.rs,tests/,src/devices/src/virtio/net/bindings.rs",
   "crate_features": ""
 }

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2018"
 clap = "2.33.3"
 
 vmm = { path = "../vmm" }
+
+[dev-dependencies]
+linux-loader = "0.4.0"

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -82,7 +82,9 @@ mod tests {
     use super::*;
 
     use std::path::PathBuf;
-    use vmm::DEFAULT_KERNEL_CMDLINE;
+
+    use linux_loader::cmdline::Cmdline;
+
     use vmm::{KernelConfig, MemoryConfig, VcpuConfig};
 
     #[test]
@@ -212,6 +214,9 @@ mod tests {
         ])
         .is_err());
 
+        let mut foo_cmdline = Cmdline::new(4096);
+        foo_cmdline.insert_str("\"foo=bar bar=foo\"").unwrap();
+
         // OK.
         assert_eq!(
             Cli::launch(vec![
@@ -227,7 +232,7 @@ mod tests {
             VMMConfig {
                 kernel_config: KernelConfig {
                     path: PathBuf::from("/foo/bar"),
-                    cmdline: "\"foo=bar bar=foo\"".to_string(),
+                    cmdline: foo_cmdline,
                     load_addr: 42,
                 },
                 memory_config: MemoryConfig { size_mib: 128 },
@@ -243,7 +248,7 @@ mod tests {
             VMMConfig {
                 kernel_config: KernelConfig {
                     path: PathBuf::from("/foo/bar"),
-                    cmdline: DEFAULT_KERNEL_CMDLINE.to_string(),
+                    cmdline: KernelConfig::default_cmdline(),
                     load_addr: 1048576,
                 },
                 memory_config: MemoryConfig { size_mib: 256 },

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -11,7 +11,7 @@ kvm-ioctls = "0.8.0"
 libc = "0.2.76"
 linux-loader = "0.3.0"
 log = "0.4.6"
-vm-memory = "0.5.0"
+vm-memory = "0.6.0"
 vm-superio = "0.4.0"
 vmm-sys-util = "0.8.0"
 
@@ -27,4 +27,4 @@ virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio.git"}
 utils = { path = "../utils" }
 
 [dev-dependencies]
-vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.6.0", features = ["backend-mmap"] }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 event-manager = { version = "0.2.1", features = ["remote_endpoint"] }
 kvm-ioctls = "0.8.0"
 libc = "0.2.76"
-linux-loader = "0.3.0"
+linux-loader = "0.4.0"
 log = "0.4.6"
 vm-memory = "0.6.0"
 vm-superio = "0.4.0"

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 libc = "0.2.76"
 kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.8.0"
-vm-memory = "0.5.0"
+vm-memory = "0.6.0"
 vmm-sys-util = "0.8.0"
 
 utils = { path = "../utils" }
@@ -21,4 +21,4 @@ utils = { path = "../utils" }
 vm-device = { git = "https://github.com/rust-vmm/vm-device", rev = "5847f12" }
 
 [dev-dependencies]
-vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.6.0", features = ["backend-mmap"] }

--- a/src/vm-vcpu/src/vcpu/mptable.rs
+++ b/src/vm-vcpu/src/vcpu/mptable.rs
@@ -284,7 +284,9 @@ pub fn setup_mptable<M: GuestMemory>(mem: &M, num_cpus: u8) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vm_memory::{Bytes, GuestMemoryMmap};
+
+    use vm_memory::{self, Bytes};
+    type GuestMemoryMmap = vm_memory::GuestMemoryMmap<()>;
 
     fn table_entry_size(type_: u8) -> usize {
         match u32::from(type_) {

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -10,7 +10,7 @@ event-manager = "0.2.1"
 kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.8.0"
 libc = "0.2.91"
-linux-loader = { version = "0.3.0", features = ["bzimage", "elf"] }
+linux-loader = { version = "0.4.0", features = ["bzimage", "elf"] }
 vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
 vm-superio = "0.4.0"
 vmm-sys-util = "0.8.0"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -11,7 +11,7 @@ kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.8.0"
 libc = "0.2.91"
 linux-loader = { version = "0.3.0", features = ["bzimage", "elf"] }
-vm-memory = { version = "0.5.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
 vm-superio = "0.4.0"
 vmm-sys-util = "0.8.0"
 

--- a/src/vmm/src/config/builder.rs
+++ b/src/vmm/src/config/builder.rs
@@ -192,7 +192,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::{DEFAULT_HIGH_RAM_START, DEFAULT_KERNEL_CMDLINE};
+    use crate::DEFAULT_HIGH_RAM_START;
 
     #[test]
     fn test_builder_default_err() {
@@ -255,7 +255,7 @@ mod tests {
         assert_eq!(
             vmm_config.unwrap().kernel_config,
             KernelConfig {
-                cmdline: DEFAULT_KERNEL_CMDLINE.to_string(),
+                cmdline: KernelConfig::default_cmdline(),
                 load_addr: DEFAULT_HIGH_RAM_START,
                 path: PathBuf::from("bzImage")
             }
@@ -337,7 +337,7 @@ mod tests {
                 memory_config: MemoryConfig { size_mib: 1024 },
                 vcpu_config: VcpuConfig { num: 2 },
                 kernel_config: KernelConfig {
-                    cmdline: DEFAULT_KERNEL_CMDLINE.to_string(),
+                    cmdline: KernelConfig::default_cmdline(),
                     load_addr: DEFAULT_HIGH_RAM_START,
                     path: PathBuf::from("bzImage")
                 },

--- a/src/vmm/tests/integration_tests.rs
+++ b/src/vmm/tests/integration_tests.rs
@@ -17,7 +17,7 @@ fn default_kernel_config(path: PathBuf) -> KernelConfig {
     KernelConfig {
         path,
         load_addr: 0x0010_0000, // 1 MB
-        cmdline: "console=ttyS0 i8042.nokbd reboot=t panic=1 pci=off".to_string(),
+        cmdline: KernelConfig::default_cmdline(),
     }
 }
 


### PR DESCRIPTION
This PR replaces the use of `String` with `linux_loader::Cmdline` for the `cmdline` member of the `KernelConfig` structure.

Fixes #98.