### PR TITLE
First steps towards refactoring the Virtio device model

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -1,114 +1,71 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
-use std::borrow::{Borrow, BorrowMut};
 use std::fs::OpenOptions;
-use std::ops::DerefMut;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use virtio_blk::stdio_executor::StdIoBackend;
-use virtio_device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
 use virtio_queue::Queue;
-use vm_device::bus::MmioAddress;
-use vm_device::device_manager::MmioManager;
-use vm_device::{DeviceMmio, MutDeviceMmio};
 use vm_memory::GuestAddressSpace;
+use vmm_sys_util::eventfd::EventFd;
 
-use crate::virtio::block::{BLOCK_DEVICE_ID, VIRTIO_BLK_F_RO};
-use crate::virtio::{CommonConfig, Env, SingleFdSignalQueue, QUEUE_MAX_SIZE};
+use crate::virtio::block::{Error, Result, BLOCK_DEVICE_ID, VIRTIO_BLK_F_RO};
+use crate::virtio::{RefVirtioDeviceT, SingleFdSignalQueue, Subscriber};
 
 use super::inorder_handler::InOrderQueueHandler;
 use super::queue_handler::QueueHandler;
-use super::{build_config_space, BlockArgs, Error, Result};
+use super::{build_config_space, BlockArgs};
 
 // This Block device can only use the MMIO transport for now, but we plan to reuse large parts of
 // the functionality when we implement virtio PCI as well, for example by having a base generic
 // type, and then separate concrete instantiations for `MmioConfig` and `PciConfig`.
-pub struct Block<M: GuestAddressSpace> {
-    cfg: CommonConfig<M>,
-    file_path: PathBuf,
-    read_only: bool,
-    // We'll prob need to remember this for state save/restore unless we pass the info from
-    // the outside.
-    _root_device: bool,
+pub struct Block {
+    args: BlockArgs,
 }
 
-impl<M> Block<M>
-where
-    M: GuestAddressSpace + Clone + Send + 'static,
-{
-    // Helper method that only creates a `Block` object.
-    fn create_block<B>(env: &mut Env<M, B>, args: &BlockArgs) -> Result<Self> {
-        let device_features = args.device_features();
-
-        // A block device has a single queue.
-        let queues = vec![Queue::new(env.mem.clone(), QUEUE_MAX_SIZE)];
-        let config_space = build_config_space(&args.file_path)?;
-        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
-
-        let common_cfg = CommonConfig::new(virtio_cfg, env).map_err(Error::Virtio)?;
-
-        Ok(Block {
-            cfg: common_cfg,
-            file_path: args.file_path.clone(),
-            read_only: args.read_only,
-            _root_device: args.root_device,
-        })
-    }
-
-    // Create `Block` object, register it on the MMIO bus, and add any extra required info to
-    // the kernel cmdline from the environment.
-    pub fn new<B>(env: &mut Env<M, B>, args: &BlockArgs) -> Result<Arc<Mutex<Self>>>
-    where
-        // We're using this (more convoluted) bound so we can pass both references and smart
-        // pointers such as mutex guards here.
-        B: DerefMut,
-        B::Target: MmioManager<D = Arc<dyn DeviceMmio + Send + Sync>>,
-    {
-        let block = Arc::new(Mutex::new(Self::create_block(env, args)?));
-
-        // Register the device on the MMIO bus.
-        env.register_mmio_device(block.clone())
-            .map_err(Error::Virtio)?;
-
-        env.insert_cmdline_str(args.cmdline_config_substring())
-            .map_err(Error::Virtio)?;
-
-        Ok(block)
+impl Block {
+    pub fn new(args: BlockArgs) -> Self {
+        Block { args }
     }
 }
 
-impl<M: GuestAddressSpace + Clone + Send + 'static> Borrow<VirtioConfig<M>> for Block<M> {
-    fn borrow(&self) -> &VirtioConfig<M> {
-        &self.cfg.virtio
-    }
-}
+impl RefVirtioDeviceT for Block {
+    type E = Error;
 
-impl<M: GuestAddressSpace + Clone + Send + 'static> BorrowMut<VirtioConfig<M>> for Block<M> {
-    fn borrow_mut(&mut self) -> &mut VirtioConfig<M> {
-        &mut self.cfg.virtio
-    }
-}
-
-impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceType for Block<M> {
     fn device_type(&self) -> u32 {
         BLOCK_DEVICE_ID
     }
-}
 
-impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Block<M> {
-    type E = Error;
+    fn cmdline_str(&self) -> Option<String> {
+        Some(self.args.cmdline_config_substring())
+    }
 
-    fn activate(&mut self) -> Result<()> {
+    fn features(&self) -> u64 {
+        self.args.device_features()
+    }
+
+    fn num_queues(&self) -> usize {
+        1
+    }
+
+    fn config_space(&self) -> Result<Vec<u8>> {
+        build_config_space(&self.args.file_path)
+    }
+
+    fn activate<M: GuestAddressSpace + Send + 'static>(
+        &mut self,
+        s: SingleFdSignalQueue,
+        mut queues: Vec<(Queue<M>, EventFd)>,
+        driver_features: u64,
+    ) -> Result<Subscriber> {
         let file = OpenOptions::new()
             .read(true)
-            .write(!self.read_only)
-            .open(&self.file_path)
+            .write(!self.args.read_only)
+            .open(&self.args.file_path)
             .map_err(Error::OpenFile)?;
 
-        let mut features = self.cfg.virtio.driver_features;
-        if self.read_only {
+        let mut features = driver_features;
+        if self.args.read_only {
             // Not sure if the driver is expected to explicitly acknowledge the `RO` feature,
             // so adding it explicitly here when present just in case.
             features |= 1 << VIRTIO_BLK_F_RO;
@@ -117,53 +74,25 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Bloc
         // TODO: Create the backend earlier (as part of `Block::new`)?
         let disk = StdIoBackend::new(file, features).map_err(Error::Backend)?;
 
-        let driver_notify = SingleFdSignalQueue {
-            irqfd: self.cfg.irqfd.clone(),
-            interrupt_status: self.cfg.virtio.interrupt_status.clone(),
-        };
+        let (queue, ioeventfd) = queues.remove(0);
 
         let inner = InOrderQueueHandler {
-            driver_notify,
-            queue: self.cfg.virtio.queues[0].clone(),
+            driver_notify: s,
+            queue,
             disk,
         };
 
-        let mut ioevents = self.cfg.prepare_activate().map_err(Error::Virtio)?;
+        let handler = Arc::new(Mutex::new(QueueHandler { inner, ioeventfd }));
 
-        let handler = Arc::new(Mutex::new(QueueHandler {
-            inner,
-            ioeventfd: ioevents.remove(0),
-        }));
-
-        self.cfg.finalize_activate(handler).map_err(Error::Virtio)
-    }
-
-    fn reset(&mut self) -> Result<()> {
-        // Not implemented for now.
-        Ok(())
-    }
-}
-
-impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioMmioDevice<M> for Block<M> {}
-
-impl<M: GuestAddressSpace + Clone + Send + 'static> MutDeviceMmio for Block<M> {
-    fn mmio_read(&mut self, _base: MmioAddress, offset: u64, data: &mut [u8]) {
-        self.read(offset, data);
-    }
-
-    fn mmio_write(&mut self, _base: MmioAddress, offset: u64, data: &[u8]) {
-        self.write(offset, data);
+        Ok(handler)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use vmm_sys_util::tempfile::TempFile;
-
-    use crate::virtio::tests::EnvMock;
-
     use super::super::VIRTIO_BLK_F_FLUSH;
     use super::*;
+    use vmm_sys_util::tempfile::TempFile;
 
     // Restricting this for now, because registering irqfds does not work on Arm without properly
     // setting up the equivalent of the irqchip first (as part of `EnvMock::new`).
@@ -171,9 +100,6 @@ mod tests {
     #[test]
     fn test_device() {
         let tmp = TempFile::new().unwrap();
-
-        let mut mock = EnvMock::new();
-        let mut env = mock.env();
         let args = BlockArgs {
             file_path: tmp.as_path().to_path_buf(),
             read_only: true,
@@ -181,24 +107,12 @@ mod tests {
             advertise_flush: true,
         };
 
-        let block_mutex = Block::new(&mut env, &args).unwrap();
-        let block = block_mutex.lock().unwrap();
+        let block = Block::new(args);
 
         assert_eq!(block.device_type(), BLOCK_DEVICE_ID);
+        assert_eq!(block.cmdline_str().unwrap(), "root=/dev/vda ro");
 
-        assert_eq!(
-            mock.kernel_cmdline.as_str(),
-            format!(
-                "virtio_mmio.device=4K@0x{:x}:{} root=/dev/vda ro",
-                mock.mmio_cfg.range.base().0,
-                mock.mmio_cfg.gsi
-            )
-        );
-
-        assert_ne!(block.cfg.virtio.device_features & (1 << VIRTIO_BLK_F_RO), 0);
-        assert_ne!(
-            block.cfg.virtio.device_features & (1 << VIRTIO_BLK_F_FLUSH),
-            0
-        );
+        assert_ne!(block.features() & (1 << VIRTIO_BLK_F_RO), 0);
+        assert_ne!(block.features() & (1 << VIRTIO_BLK_F_FLUSH), 0);
     }
 }

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 
 use virtio_blk::stdio_executor;
 
+use crate::virtio;
 use crate::virtio::features::{VIRTIO_F_IN_ORDER, VIRTIO_F_RING_EVENT_IDX, VIRTIO_F_VERSION_1};
 
 pub use device::Block;
@@ -31,9 +32,15 @@ const SECTOR_SHIFT: u8 = 9;
 #[derive(Debug)]
 pub enum Error {
     Backend(stdio_executor::Error),
-    Virtio(crate::virtio::Error),
     OpenFile(io::Error),
     Seek(io::Error),
+    Virtio(virtio::Error),
+}
+
+impl From<virtio::Error> for Error {
+    fn from(e: virtio::Error) -> Self {
+        Error::Virtio(e)
+    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -1,0 +1,282 @@
+//! This module defines intermediate level abstractions for Virtio device implementations.
+//! They are not fully generic in the sense that we assume certain assumptions about the
+//! environment (i.e. we are using KVM, EventFds, and a couple of other things), but otherwise
+//! we are tying to identify and consolidate as much common functionality as possible, to
+//! to simplify the definition, testing, and maintenance of multiple specific Virtio device
+//! implementations.
+//!
+//! In turn, the logic here leverages higher-level functionality from rust-vmm (such as things
+//! from the virtio workspaces), with aim of creating a layered stack of abstractions, such that
+//! different use cases can identify and reuse as much as possible depending on the particular
+//! assumptions that apply.
+
+// We consolidate here as much of the common device logic as possible, and delegate the rest
+// to particular implementations via the `RefVirtioDeviceT` trait. One important thing that's
+// not currently present is state save/restore, but we're going to add that as well.
+
+use std::borrow::{Borrow, BorrowMut};
+use std::convert::TryFrom;
+use std::fmt::Debug;
+use std::result::Result;
+use std::sync::{Arc, Mutex};
+
+use event_manager::{RemoteEndpoint, SubscriberId};
+use kvm_ioctls::{IoEventAddress, VmFd};
+use virtio_device::{VirtioConfig, VirtioDeviceActions, VirtioDeviceType, VirtioMmioDevice};
+use virtio_queue::Queue;
+use vm_device::bus::MmioAddress;
+use vm_device::MutDeviceMmio;
+use vm_memory::{GuestAddress, GuestAddressSpace};
+use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
+
+use super::env::MmioEnvironment;
+use super::features;
+use super::{
+    Error, MmioConfig, SingleFdSignalQueue, Subscriber, QUEUE_MAX_SIZE,
+    VIRTIO_MMIO_QUEUE_NOTIFY_OFFSET,
+};
+
+/// Defines operations that are specific to particular Virtio device implementations.
+pub trait RefVirtioDeviceT {
+    /// The error type that can be returned by the following methods.
+    type E: Debug + From<Error>;
+
+    /// Return the Virtio device type.
+    fn device_type(&self) -> u32;
+
+    /// Return any additional parameters for the guest kernel command line that are required
+    /// by specific devices to operate (i.e. not including something like kernel cmdline parameters
+    /// used for generic Virtio over MMIO device discovery).
+    fn cmdline_str(&self) -> Option<String>;
+
+    /// Return the set of features enabled by the device.
+    fn features(&self) -> u64;
+
+    /// Return the number of queues used by the device.
+    // TODO: We may need a better abstraction here when we start dealing with devices that have
+    // a configurable number of queues.
+    fn num_queues(&self) -> usize;
+
+    /// Return the contents of the device configuration space.
+    fn config_space(&self) -> Result<Vec<u8>, Self::E>;
+
+    /// Run device-specific activation logic.
+    // TODO: Going forward, we'll likely want to have a generic type parameter for `s`, since
+    // using the same implementation might not be optimal for different use cases such as
+    // PCI vs MMIO transports.
+    fn activate<M: GuestAddressSpace + Send + 'static>(
+        &mut self,
+        s: SingleFdSignalQueue,
+        queues: Vec<(Queue<M>, EventFd)>,
+        driver_features: u64,
+    ) -> Result<Subscriber, Self::E>;
+}
+
+/// Represents a Virtio device as defined for this particular implementation and set of
+/// assumptions. Different `inner` backends are used to offer the functionality associated
+/// with various specific devices (i.e. block, net, etc.)
+// The current implementation is MMIO-specific for now; we'll extend it to support the PCI
+// transport as well in the future.
+pub struct RefVirtioDevice<M: GuestAddressSpace, D> {
+    virtio_cfg: VirtioConfig<M>,
+    mmio_cfg: MmioConfig,
+    endpoint: RemoteEndpoint<Subscriber>,
+    vm_fd: Arc<VmFd>,
+    irqfd: Arc<EventFd>,
+    inner: D,
+}
+
+impl<M, D> RefVirtioDevice<M, D>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    D: RefVirtioDeviceT + Send + 'static,
+{
+    /// Create a new device and register it with the MMIO manager.
+    pub fn new_arc<E: MmioEnvironment<M = M>>(
+        env: &mut E,
+        inner: D,
+    ) -> Result<Arc<Mutex<Self>>, D::E> {
+        let device_features = inner.features();
+
+        let queues = vec![Queue::new(env.mem(), QUEUE_MAX_SIZE); inner.num_queues()];
+
+        let config_space = inner.config_space()?;
+
+        let virtio_cfg = VirtioConfig::new(device_features, queues, config_space);
+
+        let mmio_cfg = MmioConfig {
+            gsi: env.req_gsi(None)?,
+            range: env.req_mmio_range(None, 0x1000)?,
+        };
+
+        let vm_fd = env.vm_fd();
+
+        let irqfd = Arc::new(EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?);
+        vm_fd
+            .register_irqfd(&irqfd, mmio_cfg.gsi)
+            .map_err(Error::RegisterIrqfd)?;
+
+        env.kernel_cmdline()
+            .add_virtio_mmio_device(
+                mmio_cfg.range.size(),
+                GuestAddress(mmio_cfg.range.base().0),
+                mmio_cfg.gsi,
+                None,
+            )
+            .map_err(Error::Cmdline)?;
+
+        if let Some(s) = inner.cmdline_str() {
+            env.kernel_cmdline().insert_str(s).map_err(Error::Cmdline)?;
+        }
+
+        let device = Arc::new(Mutex::new(Self {
+            virtio_cfg,
+            mmio_cfg,
+            endpoint: env.remote_endpoint(),
+            vm_fd,
+            irqfd,
+            inner,
+        }));
+
+        env.register_mmio_device(mmio_cfg.range, device.clone())?;
+
+        Ok(device)
+    }
+}
+
+impl<M, D> VirtioDeviceType for RefVirtioDevice<M, D>
+where
+    M: GuestAddressSpace + Clone + Send,
+    D: RefVirtioDeviceT,
+{
+    fn device_type(&self) -> u32 {
+        self.inner.device_type()
+    }
+}
+
+impl<M, D> Borrow<VirtioConfig<M>> for RefVirtioDevice<M, D>
+where
+    M: GuestAddressSpace + Clone + Send,
+    D: RefVirtioDeviceT,
+{
+    fn borrow(&self) -> &VirtioConfig<M> {
+        &self.virtio_cfg
+    }
+}
+
+impl<M, D> BorrowMut<VirtioConfig<M>> for RefVirtioDevice<M, D>
+where
+    M: GuestAddressSpace + Clone + Send,
+    D: RefVirtioDeviceT,
+{
+    fn borrow_mut(&mut self) -> &mut VirtioConfig<M> {
+        &mut self.virtio_cfg
+    }
+}
+
+impl<M, D> VirtioDeviceActions for RefVirtioDevice<M, D>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    D: RefVirtioDeviceT,
+{
+    type E = D::E;
+
+    // This is the implementation of the `VirtioDeviceActions::activate` method from upstream
+    // `virtio-device`, which begins by performing logic which is common to all devices, and
+    // then calls `inner.activate()` for device-specific functionality. The current contract
+    // is that `inner.activate()` returns a subscriber which we the register with the event
+    // manager from the environment, which is responsible for handling device-specific events.
+    // We'll implement the necessary changes/additions to cover nuances required by state
+    // save/restore and multi-threaded event handling as required moving forward.
+    fn activate(&mut self) -> Result<(), Self::E> {
+        if !self.virtio_cfg.queues_valid() {
+            return Err(Error::QueuesNotValid.into());
+        }
+
+        if self.virtio_cfg.device_activated {
+            return Err(Error::AlreadyActivated.into());
+        }
+
+        // We do not support legacy drivers.
+        if self.virtio_cfg.driver_features & (1 << features::VIRTIO_F_VERSION_1) == 0 {
+            return Err(Error::BadFeatures(self.virtio_cfg.driver_features).into());
+        }
+
+        let queues = self.virtio_cfg.queues.clone();
+
+        let driver_notify = SingleFdSignalQueue {
+            irqfd: self.irqfd.clone(),
+            interrupt_status: self.virtio_cfg.interrupt_status.clone(),
+        };
+
+        let mut ioevents = Vec::new();
+
+        // Right now, we operate under the assumption all queues are marked ready by the device
+        // (which is true until we start supporting devices that can optionally make use of
+        // additional queues on top of the defaults).
+        for i in 0..queues.len() {
+            let fd = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
+
+            // Register the queue event fd.
+            self.vm_fd
+                .register_ioevent(
+                    &fd,
+                    &IoEventAddress::Mmio(
+                        self.mmio_cfg.range.base().0 + VIRTIO_MMIO_QUEUE_NOTIFY_OFFSET,
+                    ),
+                    // The maximum number of queues should fit within an `u16` according to the
+                    // standard, so the conversion below is always expected to succeed.
+                    u32::try_from(i).unwrap(),
+                )
+                .map_err(Error::RegisterIoevent)?;
+
+            ioevents.push(fd);
+        }
+
+        let v = queues.into_iter().zip(ioevents.into_iter()).collect();
+
+        let handler = self
+            .inner
+            .activate(driver_notify, v, self.virtio_cfg.driver_features)?;
+
+        // Register the queue handler with the `EventManager`. We could record the `sub_id`
+        // (and/or keep a handler clone) for further interaction (i.e. to remove the subscriber at
+        // a later time, retrieve state, etc).
+        let _sub_id = self
+            .endpoint
+            .call_blocking(move |mgr| -> event_manager::Result<SubscriberId> {
+                Ok(mgr.add_subscriber(handler))
+            })
+            .map_err(Error::Endpoint)?;
+
+        self.virtio_cfg.device_activated = true;
+
+        Ok(())
+    }
+
+    fn reset(&mut self) -> Result<(), Self::E> {
+        // Not implemented for now.
+        Ok(())
+    }
+}
+
+impl<M, D> VirtioMmioDevice<M> for RefVirtioDevice<M, D>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    D: RefVirtioDeviceT,
+{
+}
+
+impl<M, D> MutDeviceMmio for RefVirtioDevice<M, D>
+where
+    M: GuestAddressSpace + Clone + Send + 'static,
+    D: RefVirtioDeviceT,
+{
+    fn mmio_read(&mut self, _base: MmioAddress, offset: u64, data: &mut [u8]) {
+        self.read(offset, data);
+    }
+
+    fn mmio_write(&mut self, _base: MmioAddress, offset: u64, data: &[u8]) {
+        self.write(offset, data);
+    }
+}

--- a/src/devices/src/virtio/env.rs
+++ b/src/devices/src/virtio/env.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use event_manager::RemoteEndpoint;
+use kvm_ioctls::VmFd;
+use linux_loader::cmdline::Cmdline;
+use vm_device::bus::{MmioAddress, MmioRange};
+use vm_device::DeviceMmio;
+
+use super::{Result, Subscriber};
+
+// We want to have interfaces that clearly separate devices from the VMMs that use them, such that
+// any device can be used in a VMM that meets certain criteria, without any hard coupling between
+// the two. The traits present in this module present one way to abstract away the requirements
+// devices implemented by this crate demand from the environment where they are used. The mode of
+// operation is devices get a suitable environment handle, perform the appropriate setup, and
+// become active based on later interaction with the guest (i.e. Virtio discovery, configuration,
+// and activation). The abstractions are mostly about Virtio over MMIO for now, but can be
+// extended to support the Virtio over PCI transport later.
+
+/// The `Environment` trait stands for a set of operations that Virtio devices in this crate
+/// expect to perform on the VMM/context where they are added to perform their initial setup.
+pub trait Environment {
+    /// Stands for the memory abstraction used by the environment.
+    type M;
+
+    /// Return an object is used to interact with the memory of the guest.
+    // TODO: We'll prob want to return a reference here vs. an owned object, but we'll need some
+    // adjustments/changes in upstream `vm-memory` first.
+    fn mem(&self) -> Self::M;
+
+    /// Return a handle to the `VmFd` object for the underlying KVM vm.
+    fn vm_fd(&self) -> Arc<VmFd>;
+
+    /// Request a `gsi` number from the environment. The `specific` argument can be used to
+    /// demand a specific value (or an error when that's not available). When `specific` is
+    /// `None` we'll just get the next available value.
+    fn req_gsi(&mut self, specific: Option<u32>) -> Result<u32>;
+
+    /// Return a `RemoteEndpoint` object associated with the `EventManager` the device will
+    /// will register to.
+    // TODO: We'll likely have to adjust the interface when supporting multiple event loops
+    // (i.e. for multiple service threads).
+    fn remote_endpoint(&self) -> RemoteEndpoint<Subscriber>;
+
+    /// Return a mutable handle to the `Cmdline` that's subsequently passed to the
+    /// guest kernel at boot.
+    fn kernel_cmdline(&mut self) -> &mut Cmdline;
+}
+
+/// Represents an `Environment` which exposes some additional operations required by devices
+/// using the Virtio over MMIO transport.
+pub trait MmioEnvironment: Environment {
+    /// Request a (potentially specific) MMIO range to be allocated for use by the device.
+    fn req_mmio_range(&mut self, base: Option<MmioAddress>, size: u64) -> Result<MmioRange>;
+
+    /// Register a `DeviceMmio` trait object with the device manger present in the environment.
+    fn register_mmio_device(
+        &mut self,
+        range: MmioRange,
+        device: Arc<dyn DeviceMmio + Sync + Send>,
+    ) -> Result<()>;
+}

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -4,6 +4,7 @@
 // We're only providing virtio over MMIO devices for now, but we aim to add PCI support as well.
 
 pub mod block;
+mod device;
 mod env;
 pub mod net;
 
@@ -26,6 +27,7 @@ use vm_memory::{GuestAddress, GuestAddressSpace};
 use vmm_sys_util::errno;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
 
+pub use device::{RefVirtioDevice, RefVirtioDeviceT};
 pub use env::{Environment, MmioEnvironment};
 
 // TODO: Move virtio-related defines from the local modules to the `vm-virtio` crate upstream.


### PR DESCRIPTION
This PR brings the first of a set of changes that aims to simplify the Virtio device model of the reference VMM, reduce the amount of boilerplate code required for each individual device, and make it easier to have devices that are clearly separated from the specific VMM that uses them and become generic as long as certain assumptions are met.

The fist commit introduces two traits that model the requirements devices expect from the environment in order to perform their setup and operate, in a way which does not make any additional assumptions about the VMM. Things are mostly Virtio over MMIO specific for now, but can be adapted to support the PCI transport as well in the future.

The second commit introduces the `RefVirtioDevice` abstraction, which contains logic that is common for all devices. Specific functionality is added by plugging in an inner object, which implements the `RefVirtioDeviceT` trait according to the characteristics of every particular device (i.e. block, net, etc.) Finally, the last commit showcases how the above abstractions can be used as part of the block device implementation. Future PRs will bring additional refactoring. 