### PR TITLE
Upstream cpuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "vm-memory",
+ "vmm-sys-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ name = "vm-vcpu-ref"
 version = "0.1.0"
 dependencies = [
  "kvm-bindings",
+ "kvm-ioctls",
  "vm-memory",
 ]
 
@@ -258,6 +259,7 @@ dependencies = [
  "vm-memory",
  "vm-superio",
  "vm-vcpu",
+ "vm-vcpu-ref",
  "vmm-sys-util",
 ]
 

--- a/src/vm-vcpu-ref/Cargo.toml
+++ b/src/vm-vcpu-ref/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 keywords = ["virt", "kvm", "vm"]
 
 [dependencies]
+kvm-ioctls = { version = "0.8.0" }
 kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }
 vm-memory = "0.6.0"
 

--- a/src/vm-vcpu-ref/Cargo.toml
+++ b/src/vm-vcpu-ref/Cargo.toml
@@ -16,3 +16,4 @@ vm-memory = "0.6.0"
 
 [dev-dependencies]
 vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
+vmm-sys-util = "0.8.0"

--- a/src/vm-vcpu-ref/coverage_config_x86_64.json
+++ b/src/vm-vcpu-ref/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-    "coverage_score": 96.0,
+    "coverage_score": 94.8,
     "exclude_path": "",
     "crate_features": ""
 }

--- a/src/vm-vcpu-ref/src/x86_64/cpuid.rs
+++ b/src/vm-vcpu-ref/src/x86_64/cpuid.rs
@@ -15,6 +15,7 @@ const ECX_TSC_DEADLINE_TIMER_SHIFT: u32 = 24; // TSC deadline mode of APIC timer
 const ECX_HYPERVISOR_SHIFT: u32 = 31; // Flag to be set when the cpu is running on a hypervisor.
 const EDX_HTT_SHIFT: u32 = 28; // Hyper Threading Enabled.
 
+/// Filter CPUID.
 pub fn filter_cpuid(kvm: &Kvm, vcpu_id: usize, cpu_count: usize, cpuid: &mut CpuId) {
     for entry in cpuid.as_mut_slice().iter_mut() {
         match entry.function {

--- a/src/vm-vcpu-ref/src/x86_64/cpuid.rs
+++ b/src/vm-vcpu-ref/src/x86_64/cpuid.rs
@@ -28,7 +28,7 @@ const EDX_HTT_SHIFT: u32 = 28; // Hyper Threading Enabled.
 /// use kvm_ioctls::{Error, Kvm};
 /// use vm_vcpu_ref::x86_64::cpuid::filter_cpuid;
 ///
-/// fn default_cpuid(cpu_index: usize, num_vcpus: usize) -> Result<CpuId, Error> {
+/// fn default_cpuid(cpu_index: u8, num_vcpus: u8) -> Result<CpuId, Error> {
 ///     let kvm = Kvm::new()?;
 ///     let mut cpuid = kvm.get_supported_cpuid(kvm_bindings::KVM_MAX_CPUID_ENTRIES)?;
 ///     filter_cpuid(&kvm, cpu_index, num_vcpus, &mut cpuid);
@@ -37,7 +37,7 @@ const EDX_HTT_SHIFT: u32 = 28; // Hyper Threading Enabled.
 ///
 /// # default_cpuid(0, 1).unwrap();
 /// ```
-pub fn filter_cpuid(kvm: &Kvm, vcpu_id: usize, cpu_count: usize, cpuid: &mut CpuId) {
+pub fn filter_cpuid(kvm: &Kvm, vcpu_id: u8, cpu_count: u8, cpuid: &mut CpuId) {
     for entry in cpuid.as_mut_slice().iter_mut() {
         match entry.function {
             0x01 => {
@@ -48,7 +48,7 @@ pub fn filter_cpuid(kvm: &Kvm, vcpu_id: usize, cpu_count: usize, cpuid: &mut Cpu
                 if kvm.check_extension(TscDeadlineTimer) {
                     entry.ecx |= 1 << ECX_TSC_DEADLINE_TIMER_SHIFT;
                 }
-                entry.ebx = (vcpu_id << EBX_CPUID_SHIFT) as u32
+                entry.ebx = ((vcpu_id as u32) << EBX_CPUID_SHIFT) as u32
                     | (EBX_CLFLUSH_CACHELINE << EBX_CLFLUSH_SIZE_SHIFT);
                 if cpu_count > 1 {
                     entry.ebx |= (cpu_count as u32) << EBX_CPU_COUNT_SHIFT;

--- a/src/vm-vcpu-ref/src/x86_64/cpuid.rs
+++ b/src/vm-vcpu-ref/src/x86_64/cpuid.rs
@@ -1,5 +1,5 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
-// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
 use kvm_bindings::CpuId;
@@ -15,11 +15,32 @@ const ECX_TSC_DEADLINE_TIMER_SHIFT: u32 = 24; // TSC deadline mode of APIC timer
 const ECX_HYPERVISOR_SHIFT: u32 = 31; // Flag to be set when the cpu is running on a hypervisor.
 const EDX_HTT_SHIFT: u32 = 28; // Hyper Threading Enabled.
 
-/// Filter CPUID.
+/// Updates the passed `cpuid` such that it can be used for configuring a vCPU
+/// for running.
+///
+/// # Example
+///
+/// We are recommending the `cpuid` to be created from the supported CPUID on
+/// the running host.
+///
+/// ```rust
+/// use kvm_bindings::CpuId;
+/// use kvm_ioctls::{Error, Kvm};
+/// use vm_vcpu_ref::x86_64::cpuid::filter_cpuid;
+///
+/// fn default_cpuid(cpu_index: usize, num_vcpus: usize) -> Result<CpuId, Error> {
+///     let kvm = Kvm::new()?;
+///     let mut cpuid = kvm.get_supported_cpuid(kvm_bindings::KVM_MAX_CPUID_ENTRIES)?;
+///     filter_cpuid(&kvm, cpu_index, num_vcpus, &mut cpuid);
+///     Ok(cpuid)
+/// }
+///
+/// # default_cpuid(0, 1).unwrap();
+/// ```
 pub fn filter_cpuid(kvm: &Kvm, vcpu_id: usize, cpu_count: usize, cpuid: &mut CpuId) {
     for entry in cpuid.as_mut_slice().iter_mut() {
         match entry.function {
-            1 => {
+            0x01 => {
                 // X86 hypervisor feature.
                 if entry.index == 0 {
                     entry.ecx |= 1 << ECX_HYPERVISOR_SHIFT;
@@ -34,15 +55,43 @@ pub fn filter_cpuid(kvm: &Kvm, vcpu_id: usize, cpu_count: usize, cpuid: &mut Cpu
                     entry.edx |= 1 << EDX_HTT_SHIFT;
                 }
             }
-            6 => {
+            0x06 => {
                 // Clear X86 EPB feature. No frequency selection in the hypervisor.
                 entry.ecx &= !(1 << ECX_EPB_SHIFT);
             }
-            11 => {
+            0x0B => {
                 // EDX bits 31..0 contain x2APIC ID of current logical processor.
                 entry.edx = vcpu_id as u32;
             }
             _ => (),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmm_sys_util::fam::FamStruct;
+
+    #[test]
+    fn test_filter_cpuid() {
+        // This is a bit of an artificial test because there's not much we can
+        // validate at the unit test level.
+        let vcpu_id = 0;
+        let kvm = Kvm::new().unwrap();
+
+        let mut cpuid = kvm
+            .get_supported_cpuid(kvm_bindings::KVM_MAX_CPUID_ENTRIES)
+            .unwrap();
+        let before_len = cpuid.as_fam_struct_ref().len();
+        filter_cpuid(&kvm, vcpu_id, 1, &mut cpuid);
+
+        // Check that no new entries than the supported ones are added.
+        assert_eq!(cpuid.as_fam_struct_ref().len(), before_len);
+
+        // Check that setting this cpuid to a vcpu does not yield an error.
+        let vm = kvm.create_vm().unwrap();
+        let vcpu = vm.create_vcpu(0).unwrap();
+        vcpu.set_cpuid2(&cpuid).unwrap();
     }
 }

--- a/src/vm-vcpu-ref/src/x86_64/mod.rs
+++ b/src/vm-vcpu-ref/src/x86_64/mod.rs
@@ -1,5 +1,7 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 #![cfg(target_arch = "x86_64")]
+/// Abstractions for a basic filtering of `CPUID`.
+pub mod cpuid;
 /// Abstractions for building a Global Descriptor Table (GDT).
 pub mod gdt;

--- a/src/vm-vcpu/src/vcpu/mod.rs
+++ b/src/vm-vcpu/src/vcpu/mod.rs
@@ -27,7 +27,6 @@ mod interrupts;
 use crate::vm::VmRunState;
 use interrupts::*;
 
-pub mod cpuid;
 pub mod mpspec;
 pub mod mptable;
 pub mod msr_index;

--- a/src/vm-vcpu/src/vm.rs
+++ b/src/vm-vcpu/src/vm.rs
@@ -313,7 +313,7 @@ mod tests {
             .unwrap();
         for i in 0..vm.state.num_vcpus {
             let mut cpuid = base_cpuid.clone();
-            filter_cpuid(&kvm, i as usize, vm.state.num_vcpus as usize, &mut cpuid);
+            filter_cpuid(&kvm, i, vm.state.num_vcpus, &mut cpuid);
             vm.create_vcpu(io_manager.clone(), VcpuState { cpuid, id: i }, guest_memory)
                 .unwrap();
         }

--- a/src/vm-vcpu/src/vm.rs
+++ b/src/vm-vcpu/src/vm.rs
@@ -254,9 +254,9 @@ impl<EH: 'static + ExitHandler + Send> KvmVm<EH> {
 mod tests {
     use super::*;
 
-    use crate::vcpu::cpuid::filter_cpuid;
     use crate::vcpu::mptable::MAX_SUPPORTED_CPUS;
     use crate::vm::{Error, KvmVm, VmState};
+    use vm_vcpu_ref::x86_64::cpuid::filter_cpuid;
 
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::thread::sleep;

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-
 event-manager = "0.2.1"
 kvm-bindings = { version = "0.4.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.8.0"
@@ -22,4 +21,5 @@ vm-device = { git = "https://github.com/rust-vmm/vm-device", rev = "5847f12" }
 
 devices = { path = "../devices" }
 vm-vcpu = { path = "../vm-vcpu" }
+vm-vcpu-ref = { path = "../vm-vcpu-ref" }
 utils = { path = "../utils" }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -579,7 +579,7 @@ impl Vmm {
         for index in 0..vcpu_cfg.num {
             // Set CPUID.
             let mut cpuid = base_cpuid.clone();
-            filter_cpuid(&self.kvm, index as usize, vcpu_cfg.num as usize, &mut cpuid);
+            filter_cpuid(&self.kvm, index, vcpu_cfg.num, &mut cpuid);
 
             let vcpu_state = VcpuState { cpuid, id: index };
             self.vm

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -52,8 +52,9 @@ use devices::virtio::net::{self, NetArgs};
 use devices::virtio::{Env, MmioConfig};
 
 use devices::legacy::SerialWrapper;
-use vm_vcpu::vcpu::{cpuid::filter_cpuid, VcpuState};
+use vm_vcpu::vcpu::VcpuState;
 use vm_vcpu::vm::{self, ExitHandler, KvmVm, VmState};
+use vm_vcpu_ref::x86_64::cpuid::filter_cpuid;
 
 #[cfg(target_arch = "aarch64")]
 use arch::AARCH64_MMIO_BASE;


### PR DESCRIPTION
This PR prepare the `cpuid` module for upstream. The first 3 commits should be ignored as they're part of #184. It was easier to continue the setup on top of those commits.

For the upstream, I've added tests, documentation, and some other tiny updates. More details in each corresponding commit.