### PR TITLE
RFC: add logging functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
@@ -243,6 +243,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "log",
  "utils",
  "vm-device",
  "vm-memory",
@@ -272,6 +273,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
+ "log",
  "utils",
  "vm-device",
  "vm-memory",
@@ -286,6 +288,7 @@ name = "vmm-reference"
 version = "0.1.0"
 dependencies = [
  "api",
+ "log",
  "vmm",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ license = "Apache-2.0 OR BSD-3-Clause"
 vmm = { path = "src/vmm" }
 api = { path = "src/api" }
 
+log = { version = ">=0.4", features = ["std"] }
+
 [workspace]
 members = ["src/vm-vcpu-ref"]
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,34 @@ vmm-reference                           \
     --kernel path=/path/to/kernel/image
 ```
 
+## Logging
+
+The reference VMM implements a simple logger and makes use of the `log` crate.
+The `log` crate provides macros for five log levels: `error!`, `warn!`, `info!`,
+`debug!`, and `trace!`.  The logger implementation prints messages to `stderr`
+listing the runtime, thread name, log level, source file and line of code, and
+the formatted string provided to the macro.
+
+For example, the `vcpu` module executes the following after shutting down a
+guest:
+
+```rust
+use log::info;
+...
+info!("Guest shutdown: Shutdown. Bye!");
+```
+
+This results in a log entry similar to the following:
+
+```bash
+vmm-reference: 3.336720662s: <vcpu_0> INFO:src/vm-vcpu/src/vcpu/mod.rs:325 --
+Guest shutdown: Shutdown. Bye!
+```
+
+The `logger` module defaults to setting `Debug` as the maximum log level,
+meaning all log messages with the exception of those initiated with the `trace!`
+macro will be printed.
+
 ## Testing
 
 The reference VMM is, first and foremost, a vehicle for end-to-end testing of

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -10,10 +10,11 @@ event-manager = { version = "0.2.1", features = ["remote_endpoint"] }
 kvm-ioctls = "0.8.0"
 libc = "0.2.76"
 linux-loader = "0.4.0"
-log = "0.4.6"
 vm-memory = "0.6.0"
 vm-superio = "0.4.0"
 vmm-sys-util = "0.8.0"
+
+log = { version = ">=0.4", features = ["std"] }
 
 # vm-device is not yet published on crates.io.
 # To make sure that breaking changes to vm-device are not breaking the

--- a/src/devices/src/legacy/rtc.rs
+++ b/src/devices/src/legacy/rtc.rs
@@ -6,7 +6,7 @@ use vm_device::bus::MmioAddress;
 use vm_device::MutDeviceMmio;
 use vm_superio::{rtc_pl031::NoEvents, Rtc};
 
-use utils::debug;
+use log::debug;
 
 pub struct RtcWrapper(pub Rtc<NoEvents>);
 

--- a/src/devices/src/legacy/serial.rs
+++ b/src/devices/src/legacy/serial.rs
@@ -16,7 +16,7 @@ use vm_superio::serial::{NoEvents, SerialEvents};
 use vm_superio::{Serial, Trigger};
 use vmm_sys_util::epoll::EventSet;
 
-use utils::debug;
+use log::{debug, error};
 
 /// Newtype for implementing `event-manager` functionalities.
 pub struct SerialWrapper<T: Trigger, EV: SerialEvents, W: Write>(pub Serial<T, EV, W>);
@@ -29,7 +29,7 @@ impl<T: Trigger, W: Write> MutEventSubscriber for SerialWrapper<T, NoEvents, W> 
         let mut out = [0u8; 32];
         match stdin().read(&mut out) {
             Err(e) => {
-                eprintln!("Error while reading stdin: {:?}", e);
+                error!("Error while reading stdin: {:?}", e);
             }
             Ok(count) => {
                 let event_set = events.event_set();
@@ -37,7 +37,7 @@ impl<T: Trigger, W: Write> MutEventSubscriber for SerialWrapper<T, NoEvents, W> 
                     event_set.contains(EventSet::ERROR) | event_set.contains(EventSet::HANG_UP);
                 if count > 0 {
                     if self.0.enqueue_raw_bytes(&out[..count]).is_err() {
-                        eprintln!("Failed to send bytes to the guest via serial input");
+                        error!("Failed to send bytes to the guest via serial input");
                     }
                 } else if unregister_condition {
                     // Got 0 bytes from serial input; is it a hang-up or error?

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -1,0 +1,73 @@
+// Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019 Intel Corporation.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use log::LevelFilter;
+
+use std::sync::Mutex;
+
+pub(crate) struct Logger {
+    output: Mutex<Box<dyn std::io::Write + Send>>,
+    start: std::time::Instant,
+}
+
+impl Logger {
+    pub(crate) fn init() {
+        // Default to Debug.
+        // TODO: Accept a command line argument to set the log level.
+        let log_level = LevelFilter::Debug;
+
+        let log_file: Box<dyn std::io::Write + Send> = Box::new(std::io::stderr());
+
+        match log::set_boxed_logger(Box::new(Logger {
+            output: Mutex::new(log_file),
+            start: std::time::Instant::now(),
+        })) {
+            Ok(_) => log::set_max_level(log_level),
+            Err(e) => eprintln!("Failed to initialize logger: {}.", e),
+        }
+    }
+}
+
+impl log::Log for Logger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        // Enabled for all log levels.
+        // Control filtering by calling `set_max_level`.
+        true
+    }
+
+    fn log(&self, record: &log::Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let now = std::time::Instant::now();
+        let duration = now.duration_since(self.start);
+
+        if record.file().is_some() && record.line().is_some() {
+            writeln!(
+                *(*(self.output.lock().unwrap())),
+                "vmm-reference: {:?}: <{}> {}:{}:{} -- {}",
+                duration,
+                std::thread::current().name().unwrap_or("anonymous"),
+                record.level(),
+                record.file().unwrap(),
+                record.line().unwrap(),
+                record.args()
+            )
+        } else {
+            writeln!(
+                *(*(self.output.lock().unwrap())),
+                "vmm-reference: {:?}: <{}> {}:{} -- {}",
+                duration,
+                std::thread::current().name().unwrap_or("anonymous"),
+                record.level(),
+                record.target(),
+                record.args()
+            )
+        }
+        .ok();
+    }
+
+    fn flush(&self) {}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,12 @@ use std::env;
 use api::Cli;
 use vmm::Vmm;
 
+mod logger;
+
 fn main() {
+    // Initialize the logger
+    logger::Logger::init();
+
     match Cli::launch(
         env::args()
             .collect::<Vec<String>>()

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -17,6 +17,8 @@ utils = { path = "../utils" }
 vm-vcpu-ref = { path = "../vm-vcpu-ref" }
 arch = { path = "../arch" }
 
+log = { version = ">=0.4", features = ["std"] }
+
 # vm-device is not yet published on crates.io.
 # To make sure that breaking changes to vm-device are not breaking the
 # vm-vcpu build, we're using a fixed revision.

--- a/src/vm-vcpu/src/vcpu/mod.rs
+++ b/src/vm-vcpu/src/vcpu/mod.rs
@@ -32,8 +32,6 @@ use vmm_sys_util::errno::Error as Errno;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
 use vmm_sys_util::terminal::Terminal;
 
-use utils::debug;
-
 #[cfg(target_arch = "x86_64")]
 mod interrupts;
 
@@ -50,6 +48,8 @@ use interrupts::*;
 use crate::vm::VmRunState;
 #[cfg(target_arch = "aarch64")]
 use arch::{AARCH64_FDT_MAX_SIZE, AARCH64_PHYS_MEM_START};
+
+use log::{debug, error, info};
 
 pub mod msr_index;
 pub mod msrs;
@@ -440,9 +440,9 @@ impl KvmVcpu {
                     // println!("{:#?}", exit_reason);
                     match exit_reason {
                         VcpuExit::Shutdown | VcpuExit::Hlt => {
-                            println!("Guest shutdown: {:?}. Bye!", exit_reason);
+                            info!("Guest shutdown: {:?}. Bye!", exit_reason);
                             if stdin().lock().set_canon_mode().is_err() {
-                                eprintln!("Failed to set canon mode. Stdin will not echo.");
+                                error!("Failed to set canon mode. Stdin will not echo.");
                             }
                             self.run_state.set_and_notify(VmRunState::Exiting);
                             break;

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -14,6 +14,8 @@ vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
 vm-superio = "0.4.0"
 vmm-sys-util = "0.8.0"
 
+log = { version = ">=0.4", features = ["std"] }
+
 # vm-device is not yet published on crates.io.
 # To make sure that breaking changes to vm-device are not breaking the
 # vm-vcpu build, we're using a fixed revision.

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -13,6 +13,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
+use log::error;
+
 use event_manager::{EventManager, EventOps, Events, MutEventSubscriber, SubscriberOps};
 use kvm_bindings::KVM_API_VERSION;
 #[cfg(target_arch = "x86_64")]
@@ -317,14 +319,14 @@ impl Vmm {
         #[cfg(target_arch = "aarch64")]
         self.setup_fdt()?;
         if stdin().lock().set_raw_mode().is_err() {
-            eprintln!("Failed to set raw mode on terminal. Stdin will echo.");
+            error!("Failed to set raw mode on terminal. Stdin will echo.");
         }
 
         self.vm.run(kernel_load_addr).map_err(Error::Vm)?;
         loop {
             match self.event_mgr.run() {
                 Ok(_) => (),
-                Err(e) => eprintln!("Failed to handle events: {:?}", e),
+                Err(e) => error!("Failed to handle events: {:?}", e),
             }
             if !self.exit_handler.keep_running() {
                 break;


### PR DESCRIPTION
Checking to see if this is the kind of logging implementation you're looking for to address #79.

It uses the `log` crate and implements a simple logger that I mostly copied from cloud-hypervisor:
https://github.com/cloud-hypervisor/cloud-hypervisor/blob/f151a8602c1e8b2b17258aef99abd33140622839/src/main.rs#L74-L117

I left most of the `println!` and `eprintln!` statements in `main.rs` and the `api` crates alone because these provide immediate feedback to the CLI user (e.g., printing a help message) and it didn't seem appropriate to redirect these to `stderr` with a timestamp.

I replaced remaining statements in all the crates with appropriate `info!`, `warn!`, or `error!` messages.  I also replaced usage of the `debug!` macro from the `utils` crate with the `debug!` macro provided by the `log` crate.

The implementation defaults to the `Debug` level, meaning only log entries initiated with the `trace!` macro are filtered out.  Alternately, I could implement a command line argument to set the log level, similar to the cloud-hypervisor implementation.

Also, I would appreciate feedback on how I might go about writing unit tests for the logger module.  The tests I've found elsewhere (e.g., for firecracker) support a much more complex logger implementation.