### PR TITLE
resources: properly detect machine architecture

### DIFF
--- a/resources/kernel/configs.sh
+++ b/resources/kernel/configs.sh
@@ -7,7 +7,7 @@
 # from this script. The current busybox version is compatible with glibc
 # version > 2.31.
 
-arch=$(uname -i)
+arch=$(uname -m)
 KERNEL_VERSION="5.4.81"
 
 if [[ $arch = "x86_64" ]]; then

--- a/resources/make_test_resources.sh
+++ b/resources/make_test_resources.sh
@@ -24,7 +24,7 @@ DEST_INITRD_DIR=${DEST_INITRD_DIR:="$TEST_RESOURCE_DIR/initrd"}
 # By default use 2 CPUs. User can change this to speed up the builds. 
 NPROC=${NPROC:=2}
 
-arch=$(uname -i)
+arch=$(uname -m)
 if [[ $arch = "x86_64" ]]; then
     ./kernel/make_kernel_busybox_image.sh -f elf -k vmlinux-hello-busybox -w $TMP_KERNEL_DIR -j $NPROC
     ./kernel/make_kernel_busybox_image.sh -f elf -k vmlinux-hello-busybox -w $TMP_KERNEL_DIR -j $NPROC -h


### PR DESCRIPTION
Using `uname -i` for detecting machine architecture is
problematic because it's not portable and returns
"unknown" on Debian and ArchLinux. Use `uname -m` instead.

Signed-off-by: Sergii Glushchenko <gsserge@amazon.com>