### PR TITLE
Updated to latest virtio-queue and vm-memory 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "virtio-blk"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-virtio.git#333eb78471a7707df7d277b9116073337df19503"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#d8ef45f57b46baa99e80e555deffd3fa1ab9affc"
 dependencies = [
  "log",
  "virtio-device",
@@ -248,7 +248,7 @@ dependencies = [
 [[package]]
 name = "virtio-device"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-virtio.git#333eb78471a7707df7d277b9116073337df19503"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#d8ef45f57b46baa99e80e555deffd3fa1ab9affc"
 dependencies = [
  "log",
  "virtio-queue",
@@ -257,8 +257,8 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-virtio.git#333eb78471a7707df7d277b9116073337df19503"
+version = "0.2.0"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#d8ef45f57b46baa99e80e555deffd3fa1ab9affc"
 dependencies = [
  "log",
  "vm-memory",
@@ -279,9 +279,9 @@ checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
 
 [[package]]
 name = "vm-memory"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a8ebcb86ca457f9d6e14cf97009f679952eba42f0113de5db596e514cd0e43b"
+checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
 dependencies = [
  "libc",
  "winapi",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 vm-fdt = "0.2.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -11,7 +11,7 @@ kvm-ioctls = "0.11.0"
 libc = "0.2.76"
 linux-loader = "0.4.0"
 log = "0.4.6"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vm-superio = "0.5.0"
 vmm-sys-util = "0.8.0"
 vm-device = "0.1.0"
@@ -23,4 +23,4 @@ virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio.git"}
 utils = { path = "../utils" }
 
 [dev-dependencies]
-vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -122,13 +122,13 @@ impl<M: GuestAddressSpace + Clone + Send + 'static> VirtioDeviceActions for Bloc
             interrupt_status: self.cfg.virtio.interrupt_status.clone(),
         };
 
+        let mut ioevents = self.cfg.prepare_activate().map_err(Error::Virtio)?;
+
         let inner = InOrderQueueHandler {
             driver_notify,
-            queue: self.cfg.virtio.queues[0].clone(),
+            queue: self.cfg.virtio.queues.remove(0),
             disk,
         };
-
-        let mut ioevents = self.cfg.prepare_activate().map_err(Error::Virtio)?;
 
         let handler = Arc::new(Mutex::new(QueueHandler {
             inner,

--- a/src/devices/src/virtio/block/inorder_handler.rs
+++ b/src/devices/src/virtio/block/inorder_handler.rs
@@ -53,7 +53,7 @@ where
     M: GuestAddressSpace,
     S: SignalUsedQueue,
 {
-    fn process_chain(&mut self, mut chain: DescriptorChain<M>) -> result::Result<(), Error> {
+    fn process_chain(&mut self, mut chain: DescriptorChain<M::T>) -> result::Result<(), Error> {
         let used_len = match Request::parse(&mut chain) {
             Ok(request) => self.disk.process_request(chain.memory(), &request)?,
             Err(e) => {

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -389,8 +389,8 @@ pub(crate) mod tests {
         assert!(matches!(cfg.prepare_activate(), Err(Error::QueuesNotValid)));
 
         // Let's pretend the queue has been configured such that the `is_valid` check passes.
-        cfg.virtio.queues[0].ready = true;
-        cfg.virtio.queues[0].size = 256;
+        cfg.virtio.queues[0].state.ready = true;
+        cfg.virtio.queues[0].state.size = 256;
 
         // This will fail because the "driver" didn't acknowledge `VIRTIO_F_VERSION_1`.
         assert!(matches!(cfg.prepare_activate(), Err(Error::BadFeatures(0))));

--- a/src/devices/src/virtio/net/simple_handler.rs
+++ b/src/devices/src/virtio/net/simple_handler.rs
@@ -133,7 +133,7 @@ impl<M: GuestAddressSpace, S: SignalUsedQueue> SimpleHandler<M, S> {
 
     fn send_frame_from_chain(
         &mut self,
-        chain: &mut DescriptorChain<M>,
+        chain: &mut DescriptorChain<M::T>,
     ) -> result::Result<u32, Error> {
         let mut count = 0;
 

--- a/src/vm-vcpu-ref/Cargo.toml
+++ b/src/vm-vcpu-ref/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["virt", "kvm", "vm"]
 thiserror = "1.0.30"
 kvm-ioctls = { version = "0.11.0" }
 kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 libc = "0.2.76"
 
 [dev-dependencies]
-vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 vmm-sys-util = "0.8.0"

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "1.0.30"
 libc = "0.2.76"
 kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.11.0"
-vm-memory = "0.6.0"
+vm-memory = "0.7.0"
 vmm-sys-util = ">=0.8.0"
 vm-device = "0.1.0"
 
@@ -20,4 +20,4 @@ vm-vcpu-ref = { path = "../vm-vcpu-ref" }
 arch = { path = "../arch" }
 
 [dev-dependencies]
-vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -10,7 +10,7 @@ kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.11.0"
 libc = "0.2.91"
 linux-loader = { version = "0.4.0", features = ["bzimage", "elf"] }
-vm-memory = { version = "0.6.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 vm-superio = "0.5.0"
 vmm-sys-util = "0.8.0"
 vm-device = "0.1.0"


### PR DESCRIPTION
Updated the virtio-queue, virtio-blk, virtio-device to the
commit d8ef45f and vm-memory 0.7.0.

Signed-off-by: Niculae Radu <r.niculae99@gmail.com>

### Summary of the PR

The new virtio-queue implementation does not allow `Queue` to be cloned
 since `QueueState` does not implement the `Clone` trait anymore.
The queues in `VirtioConfig` are removed after the configuration steps and
added to their corresponding handlers. 


### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
