### PR TITLE
consume i8042 device from vm-superio

### DIFF
--- a/src/devices/src/legacy/i8042.rs
+++ b/src/devices/src/legacy/i8042.rs
@@ -1,0 +1,42 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::convert::TryInto;
+use vm_device::bus::{PioAddress, PioAddressOffset};
+use vm_device::MutDevicePio;
+use vm_superio::I8042Device;
+
+use utils::debug;
+
+use super::EventFdTrigger;
+pub struct I8042Wrapper(pub I8042Device<EventFdTrigger>);
+
+impl MutDevicePio for I8042Wrapper {
+    fn pio_read(&mut self, _base: PioAddress, offset: PioAddressOffset, data: &mut [u8]) {
+        if data.len() != 1 {
+            debug!("Invalid I8042 data length on read: {}", data.len());
+            return;
+        }
+        match offset.try_into() {
+            Ok(offset) => {
+                self.0.read(offset);
+            }
+            Err(_) => debug!("Invalid I8042 read offset."),
+        }
+    }
+
+    fn pio_write(&mut self, _base: PioAddress, offset: PioAddressOffset, data: &[u8]) {
+        if data.len() != 1 {
+            debug!("Invalid I8042 data length on write: {}", data.len());
+            return;
+        }
+        match offset.try_into() {
+            Ok(offset) => {
+                if self.0.write(offset, data[0]).is_err() {
+                    debug!("Failed to write to I8042.");
+                }
+            }
+            Err(_) => debug!("Invalid I8042 write offset"),
+        }
+    }
+}

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -1,15 +1,16 @@
 // Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
-
+#[cfg(target_arch = "x86_64")]
+mod i8042;
 #[cfg(target_arch = "aarch64")]
 mod rtc;
 mod serial;
-
+#[cfg(target_arch = "x86_64")]
+pub use i8042::I8042Wrapper;
 #[cfg(target_arch = "aarch64")]
 pub use rtc::RtcWrapper;
 pub use serial::Error as SerialError;
 pub use serial::SerialWrapper;
-
 use std::io;
 use std::ops::Deref;
 

--- a/src/vm-vcpu/src/vcpu/mod.rs
+++ b/src/vm-vcpu/src/vcpu/mod.rs
@@ -684,7 +684,18 @@ impl KvmVcpu {
                                 }
                             } else if addr == 0x060 || addr == 0x061 || addr == 0x064 {
                                 // Write at the i8042 port.
+                                //i8042 is registered at port 0x64.
                                 // See https://wiki.osdev.org/%228042%22_PS/2_Controller#PS.2F2_Controller_IO_Ports
+                                #[cfg(target_arch = "x86_64")]
+                                if self
+                                    .device_mgr
+                                    .lock()
+                                    .unwrap()
+                                    .pio_write(PioAddress(addr), data)
+                                    .is_err()
+                                {
+                                    debug!("Failed to write to i8042 port")
+                                }
                             } else if (0x070..=0x07f).contains(&addr) {
                                 // Write at the RTC port.
                             } else {


### PR DESCRIPTION
Signed-off-by: Ramyak Mehra <rmehra_be19@thapar.edu>

### Summary of the PR
* Added I8042 wrapper inside devices/legacy.
* add_i8042_deive func inside src/vmm/lib.rs on the vmm struct.
* handled VcpuExit::IoOut at address i8042 port, inside vm-vcpu/src/vcpu/mod.rs

issue: #198 

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.