### PR TITLE
Save and restore vCPU state on aarch64

### DIFF
--- a/src/vm-vcpu/src/vcpu/regs.rs
+++ b/src/vm-vcpu/src/vcpu/regs.rs
@@ -1,13 +1,13 @@
-pub(crate) const KVM_REG_ARM64: u64 = 0x6000000000000000;
-pub(crate) const KVM_REG_SIZE_U64: u64 = 0x0030000000000000;
-pub(crate) const KVM_REG_ARM_COPROC_SHIFT: u64 = 16;
-pub(crate) const KVM_REG_ARM_CORE: u64 = 0x0010 << KVM_REG_ARM_COPROC_SHIFT;
+use kvm_bindings::*;
+use kvm_ioctls::VcpuFd;
+
+use super::Error;
 
 macro_rules! arm64_core_reg {
     ($reg: tt) => {
         KVM_REG_ARM64
             | KVM_REG_SIZE_U64
-            | KVM_REG_ARM_CORE
+            | u64::from(KVM_REG_ARM_CORE)
             | ((offset__of!(kvm_bindings::user_pt_regs, $reg) / 4) as u64)
     };
 }
@@ -25,4 +25,52 @@ macro_rules! offset__of {
 
         member - base
     });
+}
+
+// Compute the ID of a specific ARM64 system register similar to how
+// the kernel C macro does.
+// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/uapi/asm/kvm.h#L203
+const fn arm64_sys_reg(op0: u64, op1: u64, crn: u64, crm: u64, op2: u64) -> u64 {
+    KVM_REG_ARM64
+        | KVM_REG_SIZE_U64
+        | KVM_REG_ARM64_SYSREG as u64
+        | ((op0 << KVM_REG_ARM64_SYSREG_OP0_SHIFT) & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
+        | ((op1 << KVM_REG_ARM64_SYSREG_OP1_SHIFT) & KVM_REG_ARM64_SYSREG_OP1_MASK as u64)
+        | ((crn << KVM_REG_ARM64_SYSREG_CRN_SHIFT) & KVM_REG_ARM64_SYSREG_CRN_MASK as u64)
+        | ((crm << KVM_REG_ARM64_SYSREG_CRM_SHIFT) & KVM_REG_ARM64_SYSREG_CRM_MASK as u64)
+        | ((op2 << KVM_REG_ARM64_SYSREG_OP2_SHIFT) & KVM_REG_ARM64_SYSREG_OP2_MASK as u64)
+}
+
+// The MPIDR_EL1 register ID is defined in the kernel:
+// https://elixir.bootlin.com/linux/v4.20.17/source/arch/arm64/include/asm/sysreg.h#L135
+const MPIDR_EL1: u64 = arm64_sys_reg(3, 0, 0, 0, 5);
+
+// Get the values of all vCPU registers. The value of MPIDR register is also
+// returned as the second element of the tuple as an optimization to prevent
+// linear scan. This value is needed when saving the GIC state.
+pub fn get_regs_and_mpidr(vcpu_fd: &VcpuFd) -> Result<(Vec<kvm_one_reg>, u64), Error> {
+    // Get IDs of all registers available to the guest.
+    // For ArmV8 there are less than 500 registers.
+    let mut reg_id_list = RegList::new(500).map_err(Error::FamError)?;
+    vcpu_fd
+        .get_reg_list(&mut reg_id_list)
+        .map_err(Error::VcpuGetRegList)?;
+
+    let mut mpidr = None;
+    let mut regs = Vec::with_capacity(reg_id_list.as_slice().len());
+    for &id in reg_id_list.as_slice() {
+        let addr = vcpu_fd.get_one_reg(id).map_err(Error::VcpuGetReg)?;
+        regs.push(kvm_one_reg { id, addr });
+
+        if id == MPIDR_EL1 {
+            mpidr = Some(addr);
+        }
+    }
+
+    if mpidr.is_none() {
+        return Err(Error::VcpuGetMpidrReg);
+    }
+
+    // unwrap() is safe because of the is_none() check above
+    Ok((regs, mpidr.unwrap()))
 }


### PR DESCRIPTION
### Summary of the PR

* Save and restore per-vCPU state. For now only `mp_state` and all registers are saved. The set of saved items can be extended in future PRs if needed.
*  Implement bare bones `vm::set_state` and `vm::restore_state` and some basic testing.
* Clean up the `regs` module a bit.

Save and restore of `GIC` will be implemented in a future PR. Same goes for proper integration testing.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
