### PR TITLE
GIC state save/restore

### DIFF
--- a/src/vm-vcpu-ref/src/aarch64/mod.rs
+++ b/src/vm-vcpu-ref/src/aarch64/mod.rs
@@ -2,3 +2,4 @@
 
 /// Helpers for setting up the interrupt controller.
 pub mod interrupts;
+mod regs;

--- a/src/vm-vcpu-ref/src/aarch64/regs/dist.rs
+++ b/src/vm-vcpu-ref/src/aarch64/regs/dist.rs
@@ -1,0 +1,133 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use kvm_bindings::KVM_DEV_ARM_VGIC_GRP_DIST_REGS;
+use kvm_ioctls::DeviceFd;
+use std::ops::Range;
+
+use super::{get_regs_data, set_regs_data, GicRegState, MmioReg, Result, SimpleReg};
+
+// As per virt/kvm/arm/vgic/vgic-kvm-device.c we need
+// the number of interrupts our GIC will support to be:
+// * bigger than 32
+// * less than 1023 and
+// * a multiple of 32.
+/// The highest usable SPI on aarch64.
+const IRQ_MAX: u32 = 128;
+
+/// First usable interrupt on aarch64.
+const IRQ_BASE: u32 = 32;
+
+// Distributor registers as detailed at page 456 from
+// https://developer.arm.com/documentation/ihi0069/c/.
+// Address offsets are relative to the Distributor base
+// address defined by the system memory map.
+const GICD_CTLR: DistReg = DistReg::simple(0x0, 4);
+const GICD_STATUSR: DistReg = DistReg::simple(0x0010, 4);
+const GICD_IGROUPR: DistReg = DistReg::shared_irq(0x0080, 1);
+const GICD_ISENABLER: DistReg = DistReg::shared_irq(0x0100, 1);
+const GICD_ICENABLER: DistReg = DistReg::shared_irq(0x0180, 1);
+const GICD_ISPENDR: DistReg = DistReg::shared_irq(0x0200, 1);
+const GICD_ICPENDR: DistReg = DistReg::shared_irq(0x0280, 1);
+const GICD_ISACTIVER: DistReg = DistReg::shared_irq(0x0300, 1);
+const GICD_ICACTIVER: DistReg = DistReg::shared_irq(0x0380, 1);
+const GICD_IPRIORITYR: DistReg = DistReg::shared_irq(0x0400, 8);
+const GICD_ICFGR: DistReg = DistReg::shared_irq(0x0C00, 2);
+const GICD_IROUTER: DistReg = DistReg::shared_irq(0x6000, 64);
+
+static VGIC_DIST_REGS: &[DistReg] = &[
+    GICD_CTLR,
+    GICD_STATUSR,
+    GICD_ICENABLER,
+    GICD_ISENABLER,
+    GICD_IGROUPR,
+    GICD_IROUTER,
+    GICD_ICFGR,
+    GICD_ICPENDR,
+    GICD_ISPENDR,
+    GICD_ICACTIVER,
+    GICD_ISACTIVER,
+    GICD_IPRIORITYR,
+];
+
+/// Get distributor registers.
+pub fn dist_regs(fd: &DeviceFd) -> Result<Vec<GicRegState<u32>>> {
+    get_regs_data(
+        fd,
+        VGIC_DIST_REGS.iter(),
+        KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
+        0,
+        0,
+    )
+}
+
+/// Set distributor registers.
+pub fn set_dist_regs(fd: &DeviceFd, dist: &[GicRegState<u32>]) -> Result<()> {
+    set_regs_data(
+        fd,
+        VGIC_DIST_REGS.iter(),
+        KVM_DEV_ARM_VGIC_GRP_DIST_REGS,
+        dist,
+        0,
+        0,
+    )
+}
+
+enum DistReg {
+    Simple(SimpleReg),
+    SharedIrq(SharedIrqReg),
+}
+
+impl DistReg {
+    const fn simple(offset: u64, size: u16) -> DistReg {
+        DistReg::Simple(SimpleReg { offset, size })
+    }
+
+    const fn shared_irq(offset: u64, bits_per_irq: u8) -> DistReg {
+        DistReg::SharedIrq(SharedIrqReg {
+            offset,
+            bits_per_irq,
+        })
+    }
+}
+
+impl MmioReg for DistReg {
+    fn range(&self) -> Range<u64> {
+        match self {
+            DistReg::Simple(reg) => reg.range(),
+            DistReg::SharedIrq(reg) => reg.range(),
+        }
+    }
+}
+
+/// Some registers have variable lengths since they dedicate a specific number of bits to
+/// each interrupt. So, their length depends on the number of interrupts.
+/// (i.e the ones that are represented as GICD_REG<n>) in the documentation mentioned above.
+struct SharedIrqReg {
+    /// The offset from the component address. The register is memory mapped here.
+    offset: u64,
+    /// Number of bits per interrupt.
+    bits_per_irq: u8,
+}
+
+impl MmioReg for SharedIrqReg {
+    fn range(&self) -> Range<u64> {
+        // The ARM® TrustZone® implements a protection logic which contains a
+        // read-as-zero/write-ignore (RAZ/WI) policy.
+        // The first part of a shared-irq register, the one corresponding to the
+        // SGI and PPI IRQs (0-32) is RAZ/WI, so we skip it.
+        //
+        // It's technically possible for this operation to overflow.
+        // However, SharedIrqReg is only used to define register descriptors
+        // with constant offsets and bits_per_irq, so any overflow would be detected
+        // during testing.
+        let start = self.offset + u64::from(IRQ_BASE) * u64::from(self.bits_per_irq) / 8;
+
+        let size_in_bits = u64::from(self.bits_per_irq) * u64::from(IRQ_MAX - IRQ_BASE);
+        let mut size_in_bytes = size_in_bits / 8;
+        if size_in_bits % 8 > 0 {
+            size_in_bytes += 1;
+        }
+
+        start..start + size_in_bytes
+    }
+}

--- a/src/vm-vcpu-ref/src/aarch64/regs/icc.rs
+++ b/src/vm-vcpu-ref/src/aarch64/regs/icc.rs
@@ -1,0 +1,189 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use kvm_bindings::{KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS, KVM_DEV_ARM_VGIC_V3_MPIDR_MASK};
+use kvm_bindings::{
+    KVM_REG_ARM64_SYSREG_CRM_MASK, KVM_REG_ARM64_SYSREG_CRM_SHIFT, KVM_REG_ARM64_SYSREG_CRN_MASK,
+    KVM_REG_ARM64_SYSREG_CRN_SHIFT, KVM_REG_ARM64_SYSREG_OP0_MASK, KVM_REG_ARM64_SYSREG_OP0_SHIFT,
+    KVM_REG_ARM64_SYSREG_OP1_MASK, KVM_REG_ARM64_SYSREG_OP1_SHIFT, KVM_REG_ARM64_SYSREG_OP2_MASK,
+    KVM_REG_ARM64_SYSREG_OP2_SHIFT,
+};
+use kvm_ioctls::DeviceFd;
+
+use super::{
+    get_reg_data, get_regs_data, set_reg_data, set_regs_data, Error, GicRegState, Result, SimpleReg,
+};
+
+const SYS_ICC_SRE_EL1: SimpleReg = SimpleReg::gic_sys_reg(3, 0, 12, 12, 5);
+const SYS_ICC_CTLR_EL1: SimpleReg = SimpleReg::gic_sys_reg(3, 0, 12, 12, 4);
+const SYS_ICC_IGRPEN0_EL1: SimpleReg = SimpleReg::gic_sys_reg(3, 0, 12, 12, 6);
+const SYS_ICC_IGRPEN1_EL1: SimpleReg = SimpleReg::gic_sys_reg(3, 0, 12, 12, 7);
+const SYS_ICC_PMR_EL1: SimpleReg = SimpleReg::gic_sys_reg(3, 0, 4, 6, 0);
+const SYS_ICC_BPR0_EL1: SimpleReg = SimpleReg::gic_sys_reg(3, 0, 12, 8, 3);
+const SYS_ICC_BPR1_EL1: SimpleReg = SimpleReg::gic_sys_reg(3, 0, 12, 12, 3);
+
+static MAIN_GIC_ICC_REGS: &[SimpleReg] = &[
+    SYS_ICC_SRE_EL1,
+    SYS_ICC_CTLR_EL1,
+    SYS_ICC_IGRPEN0_EL1,
+    SYS_ICC_IGRPEN1_EL1,
+    SYS_ICC_PMR_EL1,
+    SYS_ICC_BPR0_EL1,
+    SYS_ICC_BPR1_EL1,
+];
+
+const SYS_ICC_AP0R0_EL1: SimpleReg = SimpleReg::sys_icc_ap0rn_el1(0);
+const SYS_ICC_AP0R1_EL1: SimpleReg = SimpleReg::sys_icc_ap0rn_el1(1);
+const SYS_ICC_AP0R2_EL1: SimpleReg = SimpleReg::sys_icc_ap0rn_el1(2);
+const SYS_ICC_AP0R3_EL1: SimpleReg = SimpleReg::sys_icc_ap0rn_el1(3);
+const SYS_ICC_AP1R0_EL1: SimpleReg = SimpleReg::sys_icc_ap1rn_el1(0);
+const SYS_ICC_AP1R1_EL1: SimpleReg = SimpleReg::sys_icc_ap1rn_el1(1);
+const SYS_ICC_AP1R2_EL1: SimpleReg = SimpleReg::sys_icc_ap1rn_el1(2);
+const SYS_ICC_AP1R3_EL1: SimpleReg = SimpleReg::sys_icc_ap1rn_el1(3);
+
+static AP_GIC_ICC_REGS: &[SimpleReg] = &[
+    SYS_ICC_AP0R0_EL1,
+    SYS_ICC_AP0R1_EL1,
+    SYS_ICC_AP0R2_EL1,
+    SYS_ICC_AP0R3_EL1,
+    SYS_ICC_AP1R0_EL1,
+    SYS_ICC_AP1R1_EL1,
+    SYS_ICC_AP1R2_EL1,
+    SYS_ICC_AP1R3_EL1,
+];
+
+const ICC_CTLR_EL1_PRIBITS_SHIFT: u64 = 8;
+const ICC_CTLR_EL1_PRIBITS_MASK: u64 = 7 << ICC_CTLR_EL1_PRIBITS_SHIFT;
+
+/// Structure for serializing the state of the GIC ICC regs
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct GicSysRegsState {
+    main_icc_regs: Vec<GicRegState<u64>>,
+    ap_icc_regs: Vec<Option<GicRegState<u64>>>,
+}
+
+impl SimpleReg {
+    const fn gic_sys_reg(op0: u64, op1: u64, crn: u64, crm: u64, op2: u64) -> SimpleReg {
+        let offset = (((op0 as u64) << KVM_REG_ARM64_SYSREG_OP0_SHIFT)
+            & KVM_REG_ARM64_SYSREG_OP0_MASK as u64)
+            | (((op1 as u64) << KVM_REG_ARM64_SYSREG_OP1_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP1_MASK as u64)
+            | (((crn as u64) << KVM_REG_ARM64_SYSREG_CRN_SHIFT)
+                & KVM_REG_ARM64_SYSREG_CRN_MASK as u64)
+            | (((crm as u64) << KVM_REG_ARM64_SYSREG_CRM_SHIFT)
+                & KVM_REG_ARM64_SYSREG_CRM_MASK as u64)
+            | (((op2 as u64) << KVM_REG_ARM64_SYSREG_OP2_SHIFT)
+                & KVM_REG_ARM64_SYSREG_OP2_MASK as u64);
+
+        SimpleReg { offset, size: 8 }
+    }
+
+    const fn sys_icc_ap0rn_el1(n: u64) -> SimpleReg {
+        Self::gic_sys_reg(3, 0, 12, 8, 4 | n)
+    }
+
+    const fn sys_icc_ap1rn_el1(n: u64) -> SimpleReg {
+        Self::gic_sys_reg(3, 0, 12, 9, n)
+    }
+}
+
+/// Get vCPU GIC system registers.
+pub fn icc_regs(fd: &DeviceFd, mpidr: u64) -> Result<GicSysRegsState> {
+    let main_icc_regs = get_regs_data(
+        fd,
+        MAIN_GIC_ICC_REGS.iter(),
+        KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
+        mpidr,
+        KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64,
+    )?;
+
+    let num_priority_bits = num_priority_bits(fd, mpidr)?;
+
+    let mut ap_icc_regs = Vec::with_capacity(AP_GIC_ICC_REGS.len());
+    for reg in AP_GIC_ICC_REGS {
+        if is_ap_reg_available(reg, num_priority_bits) {
+            ap_icc_regs.push(Some(get_reg_data(
+                fd,
+                reg,
+                KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
+                mpidr,
+                KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64,
+            )?));
+        } else {
+            ap_icc_regs.push(None);
+        }
+    }
+
+    Ok(GicSysRegsState {
+        main_icc_regs,
+        ap_icc_regs,
+    })
+}
+
+/// Set vCPU GIC system registers.
+pub fn set_icc_regs(fd: &DeviceFd, state: &GicSysRegsState, mpidr: u64) -> Result<()> {
+    set_regs_data(
+        fd,
+        MAIN_GIC_ICC_REGS.iter(),
+        KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
+        &state.main_icc_regs,
+        mpidr,
+        KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64,
+    )?;
+
+    let num_priority_bits = num_priority_bits(fd, mpidr)?;
+
+    for (reg, maybe_reg_data) in AP_GIC_ICC_REGS.iter().zip(&state.ap_icc_regs) {
+        if is_ap_reg_available(reg, num_priority_bits) != maybe_reg_data.is_some() {
+            return Err(Error::InvalidGicSysRegState);
+        }
+
+        if let Some(reg_data) = maybe_reg_data {
+            set_reg_data(
+                fd,
+                reg,
+                KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
+                reg_data,
+                mpidr,
+                KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn num_priority_bits(fd: &DeviceFd, mpidr: u64) -> Result<u64> {
+    let reg_val: u64 = get_reg_data(
+        fd,
+        &SYS_ICC_CTLR_EL1,
+        KVM_DEV_ARM_VGIC_GRP_CPU_SYSREGS,
+        mpidr,
+        KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64,
+    )?
+    .chunks[0];
+
+    Ok(((reg_val & ICC_CTLR_EL1_PRIBITS_MASK) >> ICC_CTLR_EL1_PRIBITS_SHIFT) + 1)
+}
+
+fn is_ap_reg_available(reg: &SimpleReg, num_priority_bits: u64) -> bool {
+    // As per ARMv8 documentation:
+    // https://developer.arm.com/documentation/ihi0069/c/
+    // page 178,
+    // ICC_AP0R1_EL1 is only implemented in implementations that support 6 or more bits of
+    // priority.
+    // ICC_AP0R2_EL1 and ICC_AP0R3_EL1 are only implemented in implementations that support
+    // 7 bits of priority.
+    if (reg == &SYS_ICC_AP0R1_EL1 || reg == &SYS_ICC_AP1R1_EL1) && num_priority_bits < 6 {
+        return false;
+    }
+    if (reg == &SYS_ICC_AP0R2_EL1
+        || reg == &SYS_ICC_AP0R3_EL1
+        || reg == &SYS_ICC_AP1R2_EL1
+        || reg == &SYS_ICC_AP1R3_EL1)
+        && num_priority_bits != 7
+    {
+        return false;
+    }
+
+    true
+}

--- a/src/vm-vcpu-ref/src/aarch64/regs/mod.rs
+++ b/src/vm-vcpu-ref/src/aarch64/regs/mod.rs
@@ -1,0 +1,192 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use kvm_bindings::{
+    kvm_device_attr, KVM_DEV_ARM_VGIC_GRP_CTRL, KVM_DEV_ARM_VGIC_SAVE_PENDING_TABLES,
+};
+use kvm_ioctls::DeviceFd;
+use std::iter::StepBy;
+use std::ops::Range;
+
+use super::interrupts::{Error, Result};
+pub use dist::{dist_regs, set_dist_regs};
+pub use icc::{icc_regs, set_icc_regs, GicSysRegsState};
+pub use redist::{redist_regs, set_redist_regs};
+
+mod dist;
+mod icc;
+mod redist;
+
+/// Generic GIC register state,
+#[derive(Clone, Debug, PartialEq)]
+pub struct GicRegState<T> {
+    pub(crate) chunks: Vec<T>,
+}
+
+/// Function that flushes RDIST pending tables into guest RAM.
+///
+/// The tables get flushed to guest RAM whenever the VM gets stopped.
+pub fn save_pending_tables(fd: &DeviceFd) -> Result<()> {
+    let init_gic_attr = kvm_device_attr {
+        group: KVM_DEV_ARM_VGIC_GRP_CTRL,
+        attr: KVM_DEV_ARM_VGIC_SAVE_PENDING_TABLES as u64,
+        addr: 0,
+        flags: 0,
+    };
+    fd.set_device_attr(&init_gic_attr)?;
+    Ok(())
+}
+
+/// Process the content of the MPIDR_EL1 register in order to be able to pass it to KVM
+///
+/// The kernel expects to find the four affinity levels of the MPIDR in the first 32 bits of the
+/// VGIC register attribute:
+/// https://elixir.free-electrons.com/linux/v4.14.203/source/virt/kvm/arm/vgic/vgic-kvm-device.c#L445.
+///
+/// The format of the MPIDR_EL1 register is:
+/// | 39 .... 32 | 31 .... 24 | 23 .... 16 | 15 .... 8 | 7 .... 0 |
+/// |    Aff3    |    Other   |    Aff2    |    Aff1   |   Aff0   |
+///
+/// The KVM mpidr format is:
+/// | 63 .... 56 | 55 .... 48 | 47 .... 40 | 39 .... 32 |
+/// |    Aff3    |    Aff2    |    Aff1    |    Aff0    |
+/// As specified in the linux kernel: Documentation/virt/kvm/devices/arm-vgic-v3.rst
+pub fn convert_to_kvm_mpidrs(mut mpidrs: Vec<u64>) -> Vec<u64> {
+    for mpidr in mpidrs.iter_mut() {
+        let cpu_affid = ((*mpidr & 0xFF_0000_0000) >> 8) | (*mpidr & 0xFF_FFFF);
+        *mpidr = cpu_affid << 32;
+    }
+    mpidrs
+}
+
+// Helper trait for working with the different types of the GIC registers
+// in a unified manner.
+trait MmioReg {
+    fn range(&self) -> Range<u64>;
+
+    fn iter<T>(&self) -> StepBy<Range<u64>>
+    where
+        Self: Sized,
+    {
+        self.range().step_by(std::mem::size_of::<T>())
+    }
+}
+
+fn set_regs_data<'a, Reg, RegChunk>(
+    fd: &DeviceFd,
+    regs: impl Iterator<Item = &'a Reg>,
+    group: u32,
+    data: &[GicRegState<RegChunk>],
+    mpidr: u64,
+    mpidr_mask: u64,
+) -> Result<()>
+where
+    Reg: MmioReg + 'a,
+    RegChunk: Clone,
+{
+    for (reg, reg_data) in regs.zip(data) {
+        set_reg_data(fd, reg, group, reg_data, mpidr, mpidr_mask)?;
+    }
+    Ok(())
+}
+
+fn set_reg_data<Reg, RegChunk>(
+    fd: &DeviceFd,
+    reg: &Reg,
+    group: u32,
+    data: &GicRegState<RegChunk>,
+    mpidr: u64,
+    mpidr_mask: u64,
+) -> Result<()>
+where
+    Reg: MmioReg,
+    RegChunk: Clone,
+{
+    for (offset, val) in reg.iter::<RegChunk>().zip(&data.chunks) {
+        let mut tmp = (*val).clone();
+        fd.set_device_attr(&kvm_device_attr(group, offset, &mut tmp, mpidr, mpidr_mask))?;
+    }
+
+    Ok(())
+}
+
+fn get_regs_data<'a, Reg, RegChunk>(
+    fd: &DeviceFd,
+    regs: impl Iterator<Item = &'a Reg>,
+    group: u32,
+    mpidr: u64,
+    mpidr_mask: u64,
+) -> Result<Vec<GicRegState<RegChunk>>>
+where
+    Reg: MmioReg + 'a,
+    RegChunk: Default,
+{
+    let mut data = Vec::new();
+    for reg in regs {
+        data.push(get_reg_data(fd, reg, group, mpidr, mpidr_mask)?);
+    }
+
+    Ok(data)
+}
+
+fn get_reg_data<Reg, RegChunk>(
+    fd: &DeviceFd,
+    reg: &Reg,
+    group: u32,
+    mpidr: u64,
+    mpidr_mask: u64,
+) -> Result<GicRegState<RegChunk>>
+where
+    Reg: MmioReg,
+    RegChunk: Default,
+{
+    let mut data = Vec::with_capacity(reg.iter::<RegChunk>().count());
+    for offset in reg.iter::<RegChunk>() {
+        let mut val = RegChunk::default();
+        fd.get_device_attr(&mut kvm_device_attr(
+            group, offset, &mut val, mpidr, mpidr_mask,
+        ))?;
+        data.push(val);
+    }
+
+    Ok(GicRegState { chunks: data })
+}
+
+fn kvm_device_attr<RegChunk>(
+    group: u32,
+    offset: u64,
+    val: &mut RegChunk,
+    mpidr: u64,
+    mpidr_mask: u64,
+) -> kvm_device_attr {
+    kvm_device_attr {
+        group,
+        attr: (mpidr & mpidr_mask) | offset,
+        addr: val as *mut RegChunk as u64,
+        flags: 0,
+    }
+}
+
+/// Structure representing a simple register.
+#[derive(PartialEq)]
+struct SimpleReg {
+    /// The offset from the component address. The register is memory mapped here.
+    offset: u64,
+    /// Size in bytes.
+    size: u16,
+}
+
+impl SimpleReg {
+    const fn new(offset: u64, size: u16) -> Self {
+        Self { offset, size }
+    }
+}
+
+impl MmioReg for SimpleReg {
+    fn range(&self) -> Range<u64> {
+        // It's technically possible for this addition to overflow.
+        // However, SimpleReg is only used to define register descriptors
+        // with constant offsets and sizes, so any overflow would be detected
+        // during testing.
+        self.offset..self.offset + u64::from(self.size)
+    }
+}

--- a/src/vm-vcpu-ref/src/aarch64/regs/redist.rs
+++ b/src/vm-vcpu-ref/src/aarch64/regs/redist.rs
@@ -1,0 +1,68 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use kvm_bindings::{KVM_DEV_ARM_VGIC_GRP_REDIST_REGS, KVM_DEV_ARM_VGIC_V3_MPIDR_MASK};
+use kvm_ioctls::DeviceFd;
+
+use super::{get_regs_data, set_regs_data, GicRegState, Result, SimpleReg};
+
+// Relevant PPI redistributor registers that we want to save/restore.
+const GICR_CTLR: SimpleReg = SimpleReg::new(0x0000, 4);
+const GICR_STATUSR: SimpleReg = SimpleReg::new(0x0010, 4);
+const GICR_WAKER: SimpleReg = SimpleReg::new(0x0014, 4);
+const GICR_PROPBASER: SimpleReg = SimpleReg::new(0x0070, 8);
+const GICR_PENDBASER: SimpleReg = SimpleReg::new(0x0078, 8);
+
+// Relevant SGI redistributor registers that we want to save/restore.
+const GICR_SGI_OFFSET: u64 = 0x0001_0000;
+const GICR_IGROUPR0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0080, 4);
+const GICR_ISENABLER0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0100, 4);
+const GICR_ICENABLER0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0180, 4);
+const GICR_ISPENDR0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0200, 4);
+const GICR_ICPENDR0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0280, 4);
+const GICR_ISACTIVER0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0300, 4);
+const GICR_ICACTIVER0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0380, 4);
+const GICR_IPRIORITYR0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0400, 32);
+const GICR_ICFGR0: SimpleReg = SimpleReg::new(GICR_SGI_OFFSET + 0x0C00, 8);
+
+// List with relevant redistributor registers and SGI associated redistributor
+// registers that we will be restoring.
+static VGIC_RDIST_AND_SGI_REGS: &[SimpleReg] = &[
+    GICR_CTLR,
+    GICR_STATUSR,
+    GICR_WAKER,
+    GICR_PROPBASER,
+    GICR_PENDBASER,
+    GICR_IGROUPR0,
+    GICR_ICENABLER0,
+    GICR_ISENABLER0,
+    GICR_ICFGR0,
+    GICR_ICPENDR0,
+    GICR_ISPENDR0,
+    GICR_ICACTIVER0,
+    GICR_ISACTIVER0,
+    GICR_IPRIORITYR0,
+];
+
+/// Get vCPU redistributor registers.
+pub fn redist_regs(fd: &DeviceFd, mpidr: u64) -> Result<Vec<GicRegState<u32>>> {
+    get_regs_data(
+        fd,
+        VGIC_RDIST_AND_SGI_REGS.iter(),
+        KVM_DEV_ARM_VGIC_GRP_REDIST_REGS,
+        mpidr,
+        KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64,
+    )
+}
+
+/// Set vCPU redistributor registers.
+pub fn set_redist_regs(fd: &DeviceFd, redist: &[GicRegState<u32>], mpidr: u64) -> Result<()> {
+    set_regs_data(
+        fd,
+        VGIC_RDIST_AND_SGI_REGS.iter(),
+        KVM_DEV_ARM_VGIC_GRP_REDIST_REGS,
+        redist,
+        mpidr,
+        KVM_DEV_ARM_VGIC_V3_MPIDR_MASK as u64,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
### Summary of the PR

Save and restore the state of GIC (Generic Interrupt Controller) as part of the general VM state on aarch64.

The GIC state consists of three groups of registers:
1. Distributor registers, implemented in the `vm-vcpu-ref/aarch64/regs/dist` module.
2. Redistributors registers per vCPU, implemented in `vm-vcpu-ref/aarch64/regs/redist`.
3. System (ICC) registers per vCPU, implemented in `vm-vcpu-ref/aarch64/regs/icc`.

For redistributors and system registers, target vCPUs are identified by MPIDR registers, stored as part of the per-vCPU state. However, when doing `get attr` and `set attr` operations on a KVM device, the value of a MPIDR register should be packed in a specific way defined in https://www.kernel.org/doc/html/latest/virt/kvm/devices/arm-vgic-v3.html. The helper function `construct_kvm_mpidrs()` is used for this conversion.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [ ] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [ ] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] Any newly added `unsafe` code is properly documented.
