### PR TITLE
Implementing IRQAllocator in vmm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "api"
 version = "0.1.0"
 dependencies = [
@@ -40,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,17 +50,26 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -97,12 +103,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -149,6 +171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -184,13 +212,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -213,12 +247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,12 +255,6 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 [[package]]
 name = "utils"
 version = "0.1.0"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "virtio-blk"
@@ -386,6 +408,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-clap = "2.33.3"
+clap = "3.2.17"
 
 vmm = { path = "../vmm" }
 

--- a/src/vm-vcpu/src/vm.rs
+++ b/src/vm-vcpu/src/vm.rs
@@ -2,6 +2,8 @@
 // Copyright 2017 The Chromium OS Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
 
+#[cfg(target_arch = "x86_64")]
+use std::convert::TryInto;
 use std::io::{self, ErrorKind};
 use std::sync::{Arc, Barrier, Mutex};
 use std::thread::{self, JoinHandle};
@@ -27,19 +29,26 @@ use vm_vcpu_ref::aarch64::interrupts::{self, Gic, GicConfig, GicState};
 #[cfg(target_arch = "x86_64")]
 use vm_vcpu_ref::x86_64::mptable::{self, MpTable};
 
+#[cfg(target_arch = "aarch64")]
+pub const MAX_IRQ: u32 = interrupts::MIN_NR_IRQS;
+#[cfg(target_arch = "x86_64")]
+pub const MAX_IRQ: u32 = mptable::IRQ_MAX as u32;
+
 /// Defines the configuration of this VM.
 #[derive(Clone)]
 pub struct VmConfig {
     pub num_vcpus: u8,
     pub vcpus_config: VcpuConfigList,
+    pub max_irq: u32,
 }
 
 impl VmConfig {
     /// Creates a default `VmConfig` for `num_vcpus`.
-    pub fn new(kvm: &Kvm, num_vcpus: u8) -> Result<Self> {
+    pub fn new(kvm: &Kvm, num_vcpus: u8, max_irq: u32) -> Result<Self> {
         Ok(VmConfig {
             num_vcpus,
             vcpus_config: VcpuConfigList::new(kvm, num_vcpus).map_err(Error::CreateVmConfig)?,
+            max_irq,
         })
     }
 }
@@ -148,6 +157,10 @@ pub enum Error {
     /// Failed to save the state of vCPUs.
     #[error("Failed to save the state of vCPUs: {0}")]
     SaveVcpuState(vcpu::Error),
+    #[cfg(target_arch = "x86_64")]
+    /// Invalid max IRQ value.
+    #[error("Invalid maximum number of IRQ: {0}")]
+    IRQMaxValue(u32),
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -229,8 +242,14 @@ impl<EH: 'static + ExitHandler + Send> KvmVm<EH> {
         let mut vm = Self::create_vm(kvm, vm_config, exit_handler, guest_memory)?;
 
         #[cfg(target_arch = "x86_64")]
-        MpTable::new(vm.config.num_vcpus)?.write(guest_memory)?;
-
+        {
+            let max_irq: u8 = vm
+                .config
+                .max_irq
+                .try_into()
+                .map_err(|_| Error::IRQMaxValue(vm.config.max_irq))?;
+            MpTable::new(vm.config.num_vcpus, max_irq)?.write(guest_memory)?;
+        }
         #[cfg(target_arch = "x86_64")]
         vm.setup_irq_controller()?;
 
@@ -314,6 +333,11 @@ impl<EH: 'static + ExitHandler + Send> KvmVm<EH> {
         self.gic.as_ref().expect("GIC is not set")
     }
 
+    /// Returns the max irq number independent of arch.
+    pub fn max_irq(&self) -> u32 {
+        self.config.max_irq
+    }
+
     // Create the kvm memory regions based on the configuration passed as `guest_memory`.
     fn configure_memory_regions<M: GuestMemory>(&self, guest_memory: &M, kvm: &Kvm) -> Result<()> {
         if guest_memory.num_regions() > kvm.get_nr_memslots() {
@@ -376,6 +400,7 @@ impl<EH: 'static + ExitHandler + Send> KvmVm<EH> {
         let gic = Gic::new(
             GicConfig {
                 num_cpus: self.config.num_vcpus,
+                num_irqs: self.config.max_irq,
                 ..Default::default()
             },
             &self.vm_fd(),
@@ -612,7 +637,7 @@ mod tests {
         guest_memory: &GuestMemoryMmap,
         num_vcpus: u8,
     ) -> Result<KvmVm<WrappedExitHandler>> {
-        let vm_config = VmConfig::new(kvm, num_vcpus).unwrap();
+        let vm_config = VmConfig::new(kvm, num_vcpus, MAX_IRQ).unwrap();
         let io_manager = Arc::new(Mutex::new(IoManager::new()));
         let exit_handler = WrappedExitHandler::default();
         let vm = KvmVm::new(kvm, vm_config, guest_memory, exit_handler, io_manager)?;
@@ -642,6 +667,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn test_max_irq_overflow() {
+        let num_vcpus = 1;
+        let kvm = Kvm::new().unwrap();
+        let guest_memory = default_memory();
+
+        let vm_config = VmConfig::new(&kvm, num_vcpus, u32::MAX).unwrap();
+        let io_manager = Arc::new(Mutex::new(IoManager::new()));
+        let exit_handler = WrappedExitHandler::default();
+        let vm = KvmVm::new(&kvm, vm_config, &guest_memory, exit_handler, io_manager);
+
+        assert!(matches!(vm, Err(Error::IRQMaxValue(_))))
+    }
+
+    #[test]
     fn test_failed_setup_memory() {
         let kvm = Kvm::new().unwrap();
 
@@ -661,7 +701,7 @@ mod tests {
     fn test_failed_irqchip_setup() {
         let kvm = Kvm::new().unwrap();
         let num_vcpus = 1;
-        let vm_state = VmConfig::new(&kvm, num_vcpus).unwrap();
+        let vm_state = VmConfig::new(&kvm, num_vcpus, MAX_IRQ).unwrap();
         let mut vm = KvmVm {
             vcpus: Vec::new(),
             vcpu_handles: Vec::new(),
@@ -670,7 +710,6 @@ mod tests {
             fd: Arc::new(kvm.create_vm().unwrap()),
             exit_handler: WrappedExitHandler::default(),
             vcpu_run_state: Arc::new(VcpuRunState::default()),
-
             #[cfg(target_arch = "aarch64")]
             gic: None,
         };

--- a/src/vmm/src/irq_allocator.rs
+++ b/src/vmm/src/irq_allocator.rs
@@ -1,0 +1,93 @@
+// Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::fmt;
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    InvalidValue,
+    MaxIrq,
+    IRQOverflowed,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// An irq allocator which gives next available irq.
+/// It is mainly used for non-legacy devices.
+// There are a few reserved irq's on x86_64. We just skip all the inital
+// reserved irq to make the implementaion simple. This could be later extended
+// to cater more complex scenario.
+#[derive(Debug)]
+pub struct IrqAllocator {
+    // Tracks the last allocated irq
+    last_used_irq: u32,
+    last_irq: u32,
+}
+
+impl IrqAllocator {
+    pub fn new(last_used_irq: u32, last_irq: u32) -> Result<Self> {
+        if last_used_irq >= last_irq {
+            return Err(Error::InvalidValue);
+        }
+        Ok(IrqAllocator {
+            last_used_irq,
+            last_irq,
+        })
+    }
+
+    pub fn next_irq(&mut self) -> Result<u32> {
+        self.last_used_irq
+            .checked_add(1)
+            .ok_or(Error::IRQOverflowed)
+            .and_then(|irq| {
+                if irq > self.last_irq {
+                    Err(Error::MaxIrq)
+                } else {
+                    self.last_used_irq = irq;
+                    Ok(irq)
+                }
+            })
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let err = match self {
+            Error::MaxIrq => "last_irq IRQ limit reached",
+            Error::IRQOverflowed => "IRQ overflowed",
+            Error::InvalidValue => {
+                "Check the value of last_used and last_irq. las_used should be less than last_irq"
+            }
+        };
+        write!(f, "{}", err) // user-facing output
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{Error, IrqAllocator};
+    #[test]
+    fn test_new() {
+        let irq_alloc = IrqAllocator::new(4, 10).unwrap();
+        assert_eq!(irq_alloc.last_used_irq, 4);
+        assert_eq!(irq_alloc.last_irq, 10);
+        let irq_alloc = IrqAllocator::new(4, 4).unwrap_err();
+        assert_eq!(irq_alloc, Error::InvalidValue);
+        let irq_alloc = IrqAllocator::new(4, 3).unwrap_err();
+        assert_eq!(irq_alloc, Error::InvalidValue);
+    }
+    #[test]
+    fn test_next_irq() {
+        let mut irq_alloc = IrqAllocator::new(4, 7).unwrap();
+        assert_eq!(irq_alloc.next_irq(), Ok(5));
+
+        let _ = irq_alloc.next_irq();
+        assert_eq!(irq_alloc.next_irq(), Ok(7));
+
+        assert_eq!(irq_alloc.next_irq(), Err(Error::MaxIrq));
+
+        let mut irq_alloc = IrqAllocator::new(u32::MAX - 1, u32::MAX).unwrap();
+        assert_eq!(irq_alloc.next_irq(), Ok(u32::MAX));
+        assert_eq!(irq_alloc.next_irq(), Err(Error::IRQOverflowed))
+    }
+}


### PR DESCRIPTION
We needed IRQAllocator for adding support
for multiple devices. IRQ_NUM for each platform is now passed
down through VMConfig. default value are used.

Signed-off-by: Ramyak mehra <rmehra_be19@thapar.edu>

### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] Any newly added `unsafe` code is properly documented.
