### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,17 +89,17 @@ dependencies = [
  "vm-device",
  "vm-memory",
  "vm-superio",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
 name = "event-manager"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377fa591135fbe23396a18e2655a6d5481bf7c5823cdfa3cc81b01a229cbe640"
+checksum = "2bbb5f730c95a458654dee0afb13f1ebb4fc3d7b772789d5f30713ec68fed75d"
 dependencies = [
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -129,22 +129,22 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78c049190826fff959994b7c1d8a2930d0a348f1b8f3aa4f9bb34cd5d7f2952"
+checksum = "efe70e65a5b092161d17f5005b66e5eefe7a94a70c332e755036fc4af78c4e79"
 dependencies = [
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
+checksum = "b8f8dc9c1896e5f144ec5d07169bc29f39a047686d29585a91f30489abfaeb6b"
 dependencies = [
  "kvm-bindings",
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ dependencies = [
  "virtio-device",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.8.0",
 ]
 
 [[package]]
@@ -285,7 +285,7 @@ source = "git+https://github.com/rust-vmm/vm-virtio.git#d8ef45f57b46baa99e80e555
 dependencies = [
  "log",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.8.0",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ dependencies = [
  "vm-device",
  "vm-memory",
  "vm-vcpu-ref",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -351,7 +351,7 @@ dependencies = [
  "libc",
  "thiserror",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -372,7 +372,7 @@ dependencies = [
  "vm-superio",
  "vm-vcpu",
  "vm-vcpu-ref",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -388,6 +388,16 @@ name = "vmm-sys-util"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b7b084231214f7427041e4220d77dfe726897a6d41fddee450696e66ff2a29"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,12 +43,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
 name = "clap"
 version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +83,7 @@ dependencies = [
  "vm-device",
  "vm-memory",
  "vm-superio",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -99,7 +93,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbb5f730c95a458654dee0afb13f1ebb4fc3d7b772789d5f30713ec68fed75d"
 dependencies = [
  "libc",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -133,7 +127,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efe70e65a5b092161d17f5005b66e5eefe7a94a70c332e755036fc4af78c4e79"
 dependencies = [
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -144,7 +138,7 @@ checksum = "b8f8dc9c1896e5f144ec5d07169bc29f39a047686d29585a91f30489abfaeb6b"
 dependencies = [
  "kvm-bindings",
  "libc",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -163,12 +157,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "os_str_bytes"
@@ -178,18 +169,18 @@ checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -202,13 +193,13 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -228,18 +219,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -247,45 +238,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "utils"
 version = "0.1.0"
 
 [[package]]
+name = "virtio-bindings"
+version = "0.2.2"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#3bbf0db2c24fe756ac3593f259d048dafc1fd3c5"
+
+[[package]]
 name = "virtio-blk"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-virtio.git#d8ef45f57b46baa99e80e555deffd3fa1ab9affc"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#3bbf0db2c24fe756ac3593f259d048dafc1fd3c5"
 dependencies = [
  "log",
+ "virtio-bindings",
  "virtio-device",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.8.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
 name = "virtio-device"
 version = "0.1.0"
-source = "git+https://github.com/rust-vmm/vm-virtio.git#d8ef45f57b46baa99e80e555deffd3fa1ab9affc"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#3bbf0db2c24fe756ac3593f259d048dafc1fd3c5"
 dependencies = [
  "log",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
 ]
 
 [[package]]
 name = "virtio-queue"
-version = "0.2.0"
-source = "git+https://github.com/rust-vmm/vm-virtio.git#d8ef45f57b46baa99e80e555deffd3fa1ab9affc"
+version = "0.10.0"
+source = "git+https://github.com/rust-vmm/vm-virtio.git#3bbf0db2c24fe756ac3593f259d048dafc1fd3c5"
 dependencies = [
  "log",
+ "virtio-bindings",
  "vm-memory",
- "vmm-sys-util 0.8.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -312,11 +311,12 @@ checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
 
 [[package]]
 name = "vm-memory"
-version = "0.7.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
+checksum = "5376c9ee5ebe2103a310d8241936cfb93c946734b0479a4fa5bdf7a64abbacd8"
 dependencies = [
  "libc",
+ "thiserror",
  "winapi",
 ]
 
@@ -339,7 +339,7 @@ dependencies = [
  "vm-device",
  "vm-memory",
  "vm-vcpu-ref",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -351,7 +351,7 @@ dependencies = [
  "libc",
  "thiserror",
  "vm-memory",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -372,7 +372,7 @@ dependencies = [
  "vm-superio",
  "vm-vcpu",
  "vm-vcpu-ref",
- "vmm-sys-util 0.11.2",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -381,16 +381,6 @@ version = "0.1.0"
 dependencies = [
  "api",
  "vmm",
-]
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf11afbc4ebc0d5c7a7748a77d19e2042677fc15faa2f4ccccb27c18a60605"
-dependencies = [
- "bitflags",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,8 +149,8 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "linux-loader"
-version = "0.4.0"
-source = "git+https://github.com/rust-vmm/linux-loader.git?rev=9a9f071#9a9f071219a8c74dcd703aec40ba0249e3a5993b"
+version = "0.10.0"
+source = "git+https://github.com/vitamin-v-software/linux-loader.git?rev=76aefef#76aefefc41c9a55217768bc0c89a55178db65b47"
 dependencies = [
  "vm-memory",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ lto = true
 panic = "abort"
 
 [patch.crates-io]
-# TODO: Using this patch until a version > 4.0 gets published.
-linux-loader = { git = "https://github.com/rust-vmm/linux-loader.git", rev = "9a9f071" }
+# TODO: Update with https://github.com/rust-vmm/linux-loader.git hash of commit
+# "add as_string() to the Cmdline crate"
+linux-loader = { git = "https://github.com/vitamin-v-software/linux-loader.git", rev = "76aefef" }

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,4 +10,4 @@ clap = "3.2.17"
 vmm = { path = "../vmm" }
 
 [dev-dependencies]
-linux-loader = "0.4.0"
+linux-loader = "0.10.0"

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -211,7 +211,7 @@ mod tests {
         ])
         .is_err());
 
-        let mut foo_cmdline = Cmdline::new(4096);
+        let mut foo_cmdline = Cmdline::new(4096).unwrap();
         foo_cmdline.insert_str("\"foo=bar bar=foo\"").unwrap();
 
         // OK.

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 vm-fdt = "0.2.0"
-vm-memory = "0.7.0"
+vm-memory = "0.13.1"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 license = "Apache-2.0 OR BSD-3-Clause"
 
 [dependencies]
-event-manager = { version = "0.2.1", features = ["remote_endpoint"] }
-kvm-ioctls = "0.11.0"
+event-manager = { version = "0.3.0", features = ["remote_endpoint"] }
+kvm-ioctls = "0.13.0"
 libc = "0.2.76"
 linux-loader = "0.4.0"
 log = "0.4.6"
 vm-memory = "0.7.0"
 vm-superio = "0.5.0"
-vmm-sys-util = "0.8.0"
+vmm-sys-util = "0.11.2"
 vm-device = "0.1.0"
 
 virtio-blk = { git = "https://github.com/rust-vmm/vm-virtio.git", features = ["backend-stdio"] }
@@ -24,4 +24,4 @@ utils = { path = "../utils" }
 
 [dev-dependencies]
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
-kvm-bindings = "0.5.0"
+kvm-bindings = "0.6.0"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -10,8 +10,8 @@ event-manager = { version = "0.3.0", features = ["remote_endpoint"] }
 kvm-ioctls = "0.13.0"
 libc = "0.2.76"
 linux-loader = "0.4.0"
-log = "0.4.6"
-vm-memory = "0.7.0"
+log = "*"
+vm-memory = "0.13.1"
 vm-superio = "0.5.0"
 vmm-sys-util = "0.11.2"
 vm-device = "0.1.0"
@@ -23,5 +23,5 @@ virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio.git"}
 utils = { path = "../utils" }
 
 [dev-dependencies]
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap"] }
 kvm-bindings = "0.6.0"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 event-manager = { version = "0.3.0", features = ["remote_endpoint"] }
 kvm-ioctls = "0.13.0"
 libc = "0.2.76"
-linux-loader = "0.4.0"
+linux-loader = "0.10.0"
 log = "*"
 vm-memory = "0.13.1"
 vm-superio = "0.5.0"

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -191,7 +191,7 @@ mod tests {
         assert_eq!(block.device_type(), BLOCK_DEVICE_ID);
 
         assert_eq!(
-            mock.kernel_cmdline.as_str(),
+            mock.kernel_cmdline.as_string().unwrap(),
             format!(
                 "virtio_mmio.device=4K@0x{:x}:{} root=/dev/vda ro",
                 mock.mmio_cfg.range.base().0,

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -332,7 +332,7 @@ pub(crate) mod tests {
                 mmio_mgr: IoManager::new(),
                 mmio_cfg,
                 // `4096` seems large enough for testing.
-                kernel_cmdline: Cmdline::new(4096),
+                kernel_cmdline: Cmdline::new(4096).unwrap(),
             }
         }
         pub fn env(&mut self) -> Env<MockMem, &mut IoManager> {
@@ -387,7 +387,7 @@ pub(crate) mod tests {
         assert_eq!(bus_range.size(), range.size());
 
         assert_eq!(
-            mock.kernel_cmdline.as_str(),
+            mock.kernel_cmdline.as_string().unwrap(),
             format!(
                 "virtio_mmio.device=4K@0x{:x}:{}",
                 range.base().0,
@@ -396,7 +396,11 @@ pub(crate) mod tests {
         );
 
         mock.env().insert_cmdline_str("ending_string").unwrap();
-        assert!(mock.kernel_cmdline.as_str().ends_with("ending_string"));
+        assert!(mock
+            .kernel_cmdline
+            .as_string()
+            .unwrap()
+            .ends_with("ending_string"));
     }
 
     #[test]

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -14,7 +14,7 @@ use std::os::raw::{c_char, c_int, c_uint, c_ulong};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 
 use vmm_sys_util::ioctl::{ioctl_with_mut_ref, ioctl_with_ref, ioctl_with_val};
-use vmm_sys_util::{ioctl_expr, ioctl_ioc_nr, ioctl_iow_nr};
+use vmm_sys_util::{ioctl_ioc_nr, ioctl_iow_nr};
 
 use super::bindings::ifreq;
 

--- a/src/vm-vcpu-ref/Cargo.toml
+++ b/src/vm-vcpu-ref/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["virt", "kvm", "vm"]
 
 [dependencies]
 thiserror = "1.0.30"
-kvm-ioctls = { version = "0.11.0" }
-kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
+kvm-ioctls = "0.13.0"
+kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 vm-memory = "0.7.0"
 libc = "0.2.76"
 
 [dev-dependencies]
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
-vmm-sys-util = "0.8.0"
+vmm-sys-util = "0.11.2"

--- a/src/vm-vcpu-ref/Cargo.toml
+++ b/src/vm-vcpu-ref/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["virt", "kvm", "vm"]
 thiserror = "1.0.30"
 kvm-ioctls = "0.13.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
-vm-memory = "0.7.0"
+vm-memory = "0.13.1"
 libc = "0.2.76"
 
 [dev-dependencies]
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap"] }
 vmm-sys-util = "0.11.2"

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "1.0.30"
 libc = "0.2.76"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.13.0"
-vm-memory = "0.7.0"
+vm-memory = "0.13.1"
 vmm-sys-util = "0.11.2"
 vm-device = "0.1.0"
 
@@ -20,4 +20,4 @@ vm-vcpu-ref = { path = "../vm-vcpu-ref" }
 arch = { path = "../arch" }
 
 [dev-dependencies]
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap"] }

--- a/src/vm-vcpu/Cargo.toml
+++ b/src/vm-vcpu/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2018"
 [dependencies]
 thiserror = "1.0.30"
 libc = "0.2.76"
-kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
-kvm-ioctls = "0.11.0"
+kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
+kvm-ioctls = "0.13.0"
 vm-memory = "0.7.0"
-vmm-sys-util = ">=0.8.0"
+vmm-sys-util = "0.11.2"
 vm-device = "0.1.0"
 
 utils = { path = "../utils" }

--- a/src/vm-vcpu/src/vcpu/mod.rs
+++ b/src/vm-vcpu/src/vcpu/mod.rs
@@ -412,7 +412,7 @@ impl KvmVcpu {
     fn set_state(&mut self, state: VcpuState) -> Result<()> {
         for reg in state.regs {
             self.vcpu_fd
-                .set_one_reg(reg.id, reg.addr)
+                .set_one_reg(reg.id, reg.addr as u128)
                 .map_err(Error::VcpuSetReg)?;
         }
 
@@ -458,7 +458,7 @@ impl KvmVcpu {
         data = (PSR_D_BIT | PSR_A_BIT | PSR_I_BIT | PSR_F_BIT | PSR_MODE_EL1h).into();
         reg_id = arm64_core_reg!(pstate);
         self.vcpu_fd
-            .set_one_reg(reg_id, data)
+            .set_one_reg(reg_id, data as u128)
             .map_err(Error::VcpuSetReg)?;
 
         // Other cpus are powered off initially
@@ -470,7 +470,7 @@ impl KvmVcpu {
             // hack -- can't get this to do offsetof(regs[0]) but luckily it's at offset 0
             reg_id = arm64_core_reg!(regs);
             self.vcpu_fd
-                .set_one_reg(reg_id, data)
+                .set_one_reg(reg_id, data as u128)
                 .map_err(Error::VcpuSetReg)?;
         }
 
@@ -682,7 +682,7 @@ impl KvmVcpu {
                 let data = ip.0;
                 let reg_id = arm64_core_reg!(pc);
                 self.vcpu_fd
-                    .set_one_reg(reg_id, data)
+                    .set_one_reg(reg_id, data as u128)
                     .map_err(Error::VcpuSetReg)?;
             }
         }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["rust-vmm AWS maintainers <rust-vmm-maintainers@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-event-manager = "0.2.1"
-kvm-bindings = { version = "0.5.0", features = ["fam-wrappers"] }
-kvm-ioctls = "0.11.0"
+event-manager = "0.3.0"
+kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
+kvm-ioctls = "0.13.0"
 libc = "0.2.91"
 linux-loader = { version = "0.4.0", features = ["bzimage", "elf"] }
 vm-allocator = "0.1.0"
 vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
 vm-superio = "0.5.0"
-vmm-sys-util = "0.8.0"
+vmm-sys-util = "0.11.2"
 vm-device = "0.1.0"
 
 devices = { path = "../devices" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -11,7 +11,7 @@ kvm-ioctls = "0.13.0"
 libc = "0.2.91"
 linux-loader = { version = "0.4.0", features = ["bzimage", "elf"] }
 vm-allocator = "0.1.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.13.1", features = ["backend-mmap"] }
 vm-superio = "0.5.0"
 vmm-sys-util = "0.11.2"
 vm-device = "0.1.0"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -9,7 +9,7 @@ event-manager = "0.3.0"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.13.0"
 libc = "0.2.91"
-linux-loader = { version = "0.4.0", features = ["bzimage", "elf"] }
+linux-loader = { version = "0.10.0", features = ["bzimage", "elf"] }
 vm-allocator = "0.1.0"
 vm-memory = { version = "0.13.1", features = ["backend-mmap"] }
 vm-superio = "0.5.0"

--- a/src/vmm/src/config/mod.rs
+++ b/src/vmm/src/config/mod.rs
@@ -147,7 +147,7 @@ pub struct KernelConfig {
 impl KernelConfig {
     /// Return the default kernel command line used by the Vmm.
     pub fn default_cmdline() -> Cmdline {
-        let mut cmdline = Cmdline::new(KERNEL_CMDLINE_CAPACITY);
+        let mut cmdline = Cmdline::new(KERNEL_CMDLINE_CAPACITY).unwrap();
 
         // It's ok to use `unwrap` because the initial capacity of `cmdline` should be
         // sufficient to accommodate the default kernel cmdline.
@@ -181,7 +181,7 @@ impl TryFrom<&str> for KernelConfig {
             .map_err(ConversionError::new_kernel)?
             .unwrap_or_else(|| DEFAULT_KERNEL_CMDLINE.to_string());
 
-        let mut cmdline = Cmdline::new(KERNEL_CMDLINE_CAPACITY);
+        let mut cmdline = Cmdline::new(KERNEL_CMDLINE_CAPACITY).unwrap();
         cmdline
             .insert_str(cmdline_str)
             .map_err(|_| ConversionError::new_kernel("Kernel cmdline capacity error"))?;
@@ -282,7 +282,7 @@ mod tests {
         // Check that additional commas in the kernel string do not cause a panic.
         let kernel_str = r#"path=/foo/bar,cmdline="foo=bar",kernel_load_addr=42,"#;
 
-        let mut foo_cmdline = Cmdline::new(128);
+        let mut foo_cmdline = Cmdline::new(128).unwrap();
         foo_cmdline.insert_str("\"foo=bar\"").unwrap();
 
         let expected_kernel_config = KernelConfig {

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -747,16 +747,13 @@ mod tests {
     use linux_loader::elf::Elf64_Ehdr;
     #[cfg(target_arch = "x86_64")]
     use linux_loader::loader::{self, bootparam::setup_header, elf::PvhBootCapability};
+    use std::fs::write;
     use std::io::ErrorKind;
     #[cfg(target_arch = "x86_64")]
     use std::path::Path;
     use std::path::PathBuf;
-    use std::fs::write;
     #[cfg(target_arch = "x86_64")]
-    use vm_memory::{
-        bytes::ByteValued,
-        Address, GuestAddress, GuestMemory,
-    };
+    use vm_memory::{bytes::ByteValued, Address, GuestAddress, GuestMemory};
 
     use vmm_sys_util::{tempdir::TempDir, tempfile::TempFile};
 
@@ -1206,7 +1203,9 @@ mod tests {
                 .with_rtc(0x40001000, 0x1000)
                 .create_fdt()
                 .unwrap();
-            assert!(fdt.write_to_mem(vmm.guest_memory.as_ref(), fdt_offset).is_err());
+            assert!(fdt
+                .write_to_mem(vmm.guest_memory.as_ref(), fdt_offset)
+                .is_err());
         }
     }
     #[test]


### PR DESCRIPTION
### Summary of the PR
This is a pull request that update the vmm-reference crate dependencies to:

- linux-loader to 0.10.0. At the moment this dependency must be checked-out locally (`linux-loader = { version = "0.10.0", path = "../linux-loader" }` in `Cargo.toml`) as it requires one commit that must be merged upstream. For this, I created another [pull request](https://github.com/rust-vmm/linux-loader/pull/169). As soon as the commit will be upstreamed I'll update this pull request to pull linux-loader directly from github.
- vm-memory 0.13.1
- kvm-ioctls 0.13.0
- kvm-bindings 0.6
- vmm-sys-util 0.11.2
- event-manager 0.3.0

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
